### PR TITLE
67-pénaliser-les-vacations-non-préférées

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -189,8 +189,19 @@ def generate_planning(agents, vacations, week_schedule):
         )
     )
     
+    # Pénaliser les vacations non désirées (évitées)
+    penalized_vacations = cp_model.LinearExpr.Sum(
+        list(
+            planning[(agent['name'], day, vacation)] * -5  # Pénalité pour les vacations non désirées
+            for agent in agents
+            for day in week_schedule
+            for vacation in vacations
+            if vacation in agent['preferences']['avoid']
+        )
+    )
+    
     # Maximiser l'objectif global, avec une préférence marquée pour les vacations préférées
-    model.Maximize(objective_preferred_vacations + objective_other_vacations)
+    model.Maximize(objective_preferred_vacations + objective_other_vacations + penalized_vacations)
         
     # Solver
     solver = cp_model.CpSolver()

--- a/backend/config.json
+++ b/backend/config.json
@@ -12,7 +12,7 @@
         "name": "Agent2",
         "preferences": {
           "preferred": ["Nuit"],
-          "avoid": ["Jour", "CDP"]
+          "avoid": ["Jour"]
           },
         "unavailable": []
         },
@@ -20,7 +20,7 @@
         "name": "Agent3",
         "preferences": {
           "preferred": ["Nuit"],
-          "avoid": ["Jour", "CDP"]
+          "avoid": ["Jour"]
           },
         "unavailable": []
         },
@@ -44,7 +44,7 @@
         "name": "Agent6",
         "preferences": {
           "preferred": ["Nuit"],
-          "avoid": ["Jour", "CDP"]
+          "avoid": ["Jour"]
           },
         "unavailable": []
         }


### PR DESCRIPTION
This pull request includes changes to the vacation planning algorithm and updates to the configuration for agent preferences. The most important changes are the addition of a penalty for undesired vacations and the removal of certain vacation types from the avoid list for several agents.

### Improvements to vacation planning algorithm:

* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR192-R204): Added a penalty for undesired vacations to the planning model, which will now penalize vacations that agents prefer to avoid. This change aims to improve the overall satisfaction of the schedule.

### Updates to agent preferences:

* [`backend/config.json`](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7L15-R23): Removed "CDP" from the avoid list for Agent2, Agent3, and Agent6, ensuring that these agents are no longer avoiding this type of vacation. [[1]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7L15-R23) [[2]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7L47-R47)