### PR TITLE
fix(planning): 🐛exclude holidays for CDP vacation assignments

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,7 @@ def load_config():
 
 config = load_config()
 weekend_days = ["Sam", "Dim"]  # Jours du week-end abrégés
+holidays = config['holidays-2024']  # Jours fériés en 2024
 
 @app.route('/')
 def home():
@@ -94,12 +95,13 @@ def generate_planning(agents, vacations, week_schedule):
         agent_name = agent['name']
         model.Add(sum(planning[(agent_name, day, vacation)] for day in week_schedule for vacation in vacations) >= 1)
         
-    # Chaque vacation doit être assignée à un agent chaque jour, sauf CDP le week-end
+    # Chaque vacation doit être assignée à un agent chaque jour, sauf CDP le week-end et les jours fériés
     for day in week_schedule:
+        day_date = day.split(" ")[1]  # Extraire la date
         for vacation in vacations:
-            # Exclusion de la vacation CDP le week-end
-            if vacation == 'CDP' and ("Sam" in day or "Dim" in day):
-                # Ne pas assigner la vacation CDP le week-end
+            # Exclusion de la vacation CDP le week-end et jours fériés
+            if vacation == 'CDP' and ("Sam" in day or "Dim" in day or day_date in holidays):
+                # Ne pas assigner la vacation CDP le week-end et jours fériés
                 model.Add(sum(planning[(agent['name'], day, 'CDP')] for agent in agents) == 0)
             else:
                 # Somme des agents assignés à une vacation spécifique pour un jour donné doit être égale à 1


### PR DESCRIPTION
This pull request includes changes to the `backend/app.py` file to enhance the scheduling logic by incorporating holidays for the year 2024. The main changes involve loading holiday data from the configuration and updating the planning generation logic to account for holidays.

Enhancements to scheduling logic:

* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR19): Added a line to load holiday data for 2024 from the configuration file. ([backend/app.pyR19](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR19))
* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadL97-R104): Updated the planning generation logic to exclude the 'CDP' vacation on holidays, in addition to weekends. ([backend/app.pyL97-R104](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadL97-R104))