### PR TITLE
feat(schedule): ✨add weekly CDP shift limit per agent

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -207,6 +207,16 @@ def generate_planning(agents, vacations, week_schedule):
             # Limiter à 36 heures par semaine
             model.Add(total_heures <= 360)  # 36 heures * 10
     ########################################################
+    
+    ########################################################
+    # Limitation du nombre de CDP à 2 par semaine
+    for agent in agents:
+        agent_name = agent['name']
+        
+        for week in weeks:
+            # Limiter le nombre de vacation CDP à 3 par semaine (du lundi au dimanche)
+            model.Add(sum(planning[(agent_name, day, 'CDP')] for day in week) <= 2)
+    ########################################################
             
     ########################################################
     # Un agent ne travaille pas quand il est indisponible


### PR DESCRIPTION
This pull request includes a change to the `generate_planning` function in `backend/app.py`. The change introduces a new constraint to limit the number of CDP shifts an agent can have per week.

New constraint added:

* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR211-R220): Added a constraint to ensure that each agent can have at most 2 CDP shifts per week.