### PR TITLE
feat(planning): ✨add constraint to prevent night shifts before agent unavailability

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -307,6 +307,28 @@ def generate_planning(agents, vacations, week_schedule):
             model.Add(sum(planning[(agent_name, day, 'Jour')] for day in days) <= 3)
     ########################################################
     
+    ########################################################
+    # Interdire une vacation de nuit avant une indisponibilité
+    for agent in agents:
+        agent_name = agent['name']
+        
+        if "unavailable" in agent:
+            # Récupérer les jours d'indisponibilité de l'agent
+            unavailable_days = agent['unavailable']
+            
+            # Parcourir chaque jour d'indisponibilité
+            for unavailable_date in unavailable_days:
+                # Extraire la portion date du jour
+                unavailable_day = datetime.strptime(unavailable_date, '%d-%m-%Y').strftime("%d-%m")
+                
+                # Interdire la vacation de nuit la veille de l'indisponibilité
+                for day_idx, day in enumerate(week_schedule[:-1]):  # Ignorer le dernier jour
+                    next_day = week_schedule[day_idx + 1]
+                    
+                    if unavailable_day in next_day:  # Vérifie si le jour correspond à une indisponibilité
+                        model.Add(planning[(agent_name, day, 'Nuit')] == 0)
+    ########################################################
+    
     # #! A retravailler sur le calcul des heures et sur la durée
     # # Un agent ne peut pas travailler plus de 48 heures par semaine
     # for agent in agents:


### PR DESCRIPTION
This pull request introduces a new constraint in the `generate_planning` function within the `backend/app.py` file. The main change ensures that agents are not scheduled for night shifts before their unavailable days.

Key changes:

* Added a constraint to prevent scheduling night shifts for agents before their unavailable days in the `generate_planning` function. This includes:
  - Extracting unavailable days for each agent.
  - Iterating through the week schedule to enforce the constraint for each day preceding an unavailable day. (`backend/app.py` [backend/app.pyR310-R331](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR310-R331))