### PR TITLE
feat: :sparkles: Configure API base URL and update planning generation endpoint

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=https://scheduleoptimization.onrender.com

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -39,6 +39,8 @@ import axios from 'axios';
 import PlanningTable from './components/PlanningTable.vue';
 import ConfigComponent from './components/ConfigComponent.vue';
 
+const API_BASE_URL = process.env.VUE_APP_API_URL;
+
 export default {
   components: {
     PlanningTable,
@@ -66,7 +68,7 @@ export default {
     async generatePlanning() {
       try {
         // Envoyer la requête à Flask pour générer le planning avec les dates de début et de fin
-        const response = await axios.post('http://127.0.0.1:5000/generate-planning', {
+        const response = await axios.post('${API_BASE_URL}/generate-planning', {
           start_date: this.startDate,
           end_date: this.endDate
         });


### PR DESCRIPTION
This pull request includes changes to the `frontend` configuration and API request handling. The most important changes include adding an environment variable for the API URL and updating the API request to use this environment variable.

Configuration changes:

* [`frontend/.env.production`](diffhunk://#diff-43d23032c06237e0fb7a9416cd2e5fbe223fe2260c7f1aafa0e5bf58f0e30918R1): Added `VUE_APP_API_URL` environment variable to store the API base URL.

API request handling:

* [`frontend/src/App.vue`](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878R42-R43): Introduced `API_BASE_URL` constant to retrieve the API URL from the environment variable.
* [`frontend/src/App.vue`](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878L69-R71): Updated the API request URL in the `generatePlanning` method to use the `API_BASE_URL` constant.