### PR TITLE
feat: :sparkles: Restrict CORS to specific origin for enhanced security

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from flask_cors import CORS
 from ortools.sat.python import cp_model
 
 app = Flask(__name__)
-CORS(app)
+CORS(app, resources={r"/*": {"origins": "https://schedule-optimization.vercel.app/"}})
 
 
 @app.route("/config")


### PR DESCRIPTION
This pull request includes a change to the CORS configuration in the `backend/app.py` file to restrict origins to a specific URL.

* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadL11-R11): Updated the CORS configuration to allow only requests from "https://schedule-optimization.vercel.app/".