### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Traceback or Screenshots**
+Put your traceback between triple backticks or if applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - Python: [e.g. 3.10.11]
+ - Flask: [e.g. 3.0]
+ - ...
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This pull request introduces a new bug report template to the repository, aimed at standardizing and improving the bug reporting process.

New bug report template:

* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R1-R32): Added a structured template for users to report bugs, including sections for bug description, steps to reproduce, expected behavior, traceback or screenshots, environment details, and additional context.