### PR TITLE
feat: :sparkles: Add restrictions for agents in the schedule

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -536,6 +536,20 @@ def generate_planning(agents, vacations, week_schedule, dayOff):
                         planning[(agent_name, monday, "Nuit")] == 0
                     ).OnlyEnforceIf([saturday_night, sunday_night])
     ########################################################
+    
+    ########################################################
+    # Appliquer les restrictions
+    for agent in agents:
+        agent_name = agent["name"]
+        
+        if "restriction" in agent:
+            restricted_vacations = agent["restriction"]
+            
+            # Interdire ces vacations pour l'agent tous les jours du planning
+            for day in week_schedule:
+                for restricted_vacation in restricted_vacations:
+                    model.Add(planning[(agent_name, day, restricted_vacation)] == 0)
+    ########################################################
 
     ########################################################
     # Soft Constraints

--- a/backend/config.json
+++ b/backend/config.json
@@ -6,6 +6,7 @@
         "preferred": ["Jour", "CDP"],
         "avoid": ["Nuit"]
         },
+      "restriction": [],
       "unavailable": [],
       "training": [],
       "exclusion": [],
@@ -20,6 +21,7 @@
         "preferred": ["Nuit"],
         "avoid": ["Jour", "CDP"]
         },
+      "restriction": ["Jour"],
       "unavailable": [],
       "training": [],
       "exclusion": ["01-01-2025"],
@@ -34,6 +36,7 @@
         "preferred": ["Nuit"],
         "avoid": []
         },
+      "restriction": [],
       "unavailable": ["21-01-2025"],
       "training": [],
       "exclusion": [],
@@ -45,7 +48,8 @@
         "preferred": ["Jour", "CDP"],
         "avoid": ["Nuit"]
         },
-      "unavailable": [],
+      "restriction": [],
+      "unavailable": ["08-02-2025", "09-02-2025"],
       "training": [],
       "exclusion": ["01-01-2025", "11-01-2025", "12-01-2025"],
       "vacation": {}
@@ -56,12 +60,13 @@
         "preferred": ["Jour", "CDP"],
         "avoid": ["Nuit"]
         },
+      "restriction": ["Nuit"],
       "unavailable": ["08-03-2025", "12-03-2025"],
       "training": [],
       "exclusion": [],
       "vacation": {
         "start": "17-02-2025",
-        "end": "21-02-2025"
+        "end": "23-02-2025"
       }
       },
     {
@@ -70,6 +75,7 @@
         "preferred": ["Nuit"],
         "avoid": []
         },
+      "restriction": [],
       "unavailable": [],
       "training": [],
       "exclusion": [],


### PR DESCRIPTION
This pull request includes changes to the `generate_planning` function in `backend/app.py` and updates to the `backend/config.json` file to introduce a new "restriction" feature for agents' schedules. The most important changes are listed below.

### Feature addition:

* [`backend/app.py`](diffhunk://#diff-a29ff322ddbacd468fea10dfb6857e1026da13b23b9ae94e4c4d0e7d2c794dadR540-R553): Added logic in `generate_planning` to apply restrictions for agents, preventing them from being scheduled for specific vacations on any day in the planning.

### Configuration updates:

* [`backend/config.json`](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R9): Added the "restriction" field for agents to specify restricted vacations. This field is used to define which vacations an agent should not be scheduled for. [[1]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R9) [[2]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R24) [[3]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R39) [[4]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7L48-R52) [[5]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R63-R69) [[6]](diffhunk://#diff-084bcebc01b1ccbc32dc9831aa38f50c9fadd01fbffe67ecbf55c03dac9db4c7R78)