### PR TITLE
Add tests for previous week's schedule and invalid data handling

### DIFF
--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -64,7 +64,16 @@ def setup_correct_data():
         "Dim. 07-01",
     ]
     dayOff = ["01-01-2023", "02-01-2023"]
-    return agents, vacations, week_schedule, dayOff
+    previous_week_schedule = [
+        "Lun. 25-12",
+        "Mar. 26-12",
+        "Mer. 27-12",
+        "Jeu. 28-12",
+        "Ven. 29-12",
+        "Sam. 30-12",
+        "Dim. 31-12",
+        ]
+    return agents, vacations, week_schedule, dayOff, previous_week_schedule
 
 
 @pytest.fixture
@@ -161,6 +170,7 @@ def test_generate_planning_valid_data(setup_correct_data):
             - vacations (list): A list of vacation periods.
             - week_schedule (list): A list representing the weekly schedule.
             - dayOff (list): A list of days off.
+            - previous_week_schedule (list): A list representing the previous week's schedule.
 
     Asserts:
         - The result is an instance of a dictionary.
@@ -168,8 +178,8 @@ def test_generate_planning_valid_data(setup_correct_data):
           "Agent5", and "Agent6".
     """
 
-    agents, vacations, week_schedule, dayOff = setup_correct_data
-    result = generate_planning(agents, vacations, week_schedule, dayOff)
+    agents, vacations, week_schedule, dayOff, previous_week_schedule = setup_correct_data
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule, initial_shifts={})
     assert isinstance(result, dict)
     assert "Agent1" in result
     assert "Agent2" in result
@@ -177,6 +187,15 @@ def test_generate_planning_valid_data(setup_correct_data):
     assert "Agent4" in result
     assert "Agent5" in result
     assert "Agent6" in result
+
+
+def test_generate_planning_valid_data_with_initial_shifts(setup_correct_data):
+    agents, vacations, week_schedule, dayOff, previous_week_schedule = setup_correct_data
+    initial_shifts = {"Agent1": [("Dim. 31-12", "Jour")], "Agent2": [("Dim. 31-12", "Nuit")]}
+
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule, initial_shifts)
+    assert "Agent1" in result
+    assert "Agent2" in result
 
 
 def test_generate_planning_invalid_data(setup_incorrect_data):
@@ -195,7 +214,7 @@ def test_generate_planning_invalid_data(setup_incorrect_data):
     """
 
     agents, vacations, week_schedule, dayOff = setup_incorrect_data
-    result = generate_planning(agents, vacations, week_schedule, dayOff)
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule=[], initial_shifts={})
     assert isinstance(result, dict)
     assert "info" in result
 
@@ -219,7 +238,7 @@ def test_generate_planning_valid_dataless(setup_correct_dataless):
     """
 
     agents, vacations, week_schedule, dayOff = setup_correct_dataless
-    result = generate_planning(agents, vacations, week_schedule, dayOff)
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule=[], initial_shifts={})
     assert isinstance(result, dict)
     assert "info" in result
 
@@ -232,17 +251,20 @@ def test_agent_unavailability(setup_correct_data):
     (day or night) to agents on their specified unavailable dates.
 
     Args:
-        setup_correct_data (tuple): A fixture that provides the necessary data
-                                    for the test, including agents, vacations,
-                                    week schedule, and days off.
+        setup_correct_data (tuple): A tuple containing the following elements:
+            - agents (list): A list of agent names.
+            - vacations (list): A list of vacation periods.
+            - week_schedule (list): A list representing the weekly schedule.
+            - dayOff (list): A list of days off.
+            - previous_week_schedule (list): A list representing the previous week's schedule.
 
     Asserts:
         The test asserts that for each agent, the specified unavailable dates
         and shifts are not present in the generated planning result.
     """
 
-    agents, vacations, week_schedule, dayOff = setup_correct_data
-    result = generate_planning(agents, vacations, week_schedule, dayOff)
+    agents, vacations, week_schedule, dayOff, previous_week_schedule = setup_correct_data
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule, initial_shifts={})
     assert ("Lun. 01-01", "Jour") not in result["Agent1"]
     assert ("Lun. 01-01", "Nuit") not in result["Agent1"]
     assert ("Mer. 03-01", "Jour") not in result["Agent2"]
@@ -266,18 +288,19 @@ def test_agent_training(setup_correct_data):
 
     Args:
         setup_correct_data (tuple): A tuple containing the following elements:
-            - agents: List of agents.
-            - vacations: List of vacations.
-            - week_schedule: Weekly schedule.
-            - dayOff: List of days off.
+            - agents (list): A list of agent names.
+            - vacations (list): A list of vacation periods.
+            - week_schedule (list): A list representing the weekly schedule.
+            - dayOff (list): A list of days off.
+            - previous_week_schedule (list): A list representing the previous week's schedule.
 
     Asserts:
         The test checks that the specified agents do not have any shifts (day or night)
         on the days they are supposed to be in training.
     """
 
-    agents, vacations, week_schedule, dayOff = setup_correct_data
-    result = generate_planning(agents, vacations, week_schedule, dayOff)
+    agents, vacations, week_schedule, dayOff, previous_week_schedule = setup_correct_data
+    result = generate_planning(agents, vacations, week_schedule, dayOff, previous_week_schedule, initial_shifts={})
     assert ("Mar. 02-01", "Jour") not in result["Agent1"]
     assert ("Mar. 02-01", "Nuit") not in result["Agent1"]
     assert ("Jeu. 04-01", "Jour") not in result["Agent2"]

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import pytest
 from app import (
+    get_previous_week_schedule,
     get_week_schedule,
     is_vacation_day,
     is_valid_date,
@@ -660,3 +661,39 @@ def test_is_weekend_friday():
     """
 
     assert not is_weekend("Ven. 07-01")
+
+
+@pytest.mark.parametrize("start_date_str, expected_output", [
+    # Test case 1: Standard date
+    ("2023-10-15", ["Dim. 08-10", "Lun. 09-10", "Mar. 10-10", "Mer. 11-10", "Jeu. 12-10", "Ven. 13-10", "Sam. 14-10"]),
+    
+    # Test case 2: Date at the beginning of the year
+    ("2023-01-05", ["Jeu. 29-12", "Ven. 30-12", "Sam. 31-12", "Dim. 01-01", "Lun. 02-01", "Mar. 03-01", "Mer. 04-01"]),
+    
+    # Test case 3: Date at the end of the year
+    ("2023-12-31", ["Dim. 24-12", "Lun. 25-12", "Mar. 26-12", "Mer. 27-12", "Jeu. 28-12", "Ven. 29-12", "Sam. 30-12"]),
+    
+    # Test case 4: Leap year date
+    ("2024-03-01", ["Ven. 23-02", "Sam. 24-02", "Dim. 25-02", "Lun. 26-02", "Mar. 27-02", "Mer. 28-02", "Jeu. 29-02"]),
+    
+    # Test case 5: Middle of the year
+    ("2023-07-15", ["Sam. 08-07", "Dim. 09-07", "Lun. 10-07", "Mar. 11-07", "Mer. 12-07", "Jeu. 13-07", "Ven. 14-07"]),
+    
+    # Test case 6: Date with single digit day and month
+    ("2023-04-05", ["Mer. 29-03", "Jeu. 30-03", "Ven. 31-03", "Sam. 01-04", "Dim. 02-04", "Lun. 03-04", "Mar. 04-04"]),
+    
+    # Test case 7: Date in February (non-leap year)
+    ("2023-02-20", ["Lun. 13-02", "Mar. 14-02", "Mer. 15-02", "Jeu. 16-02", "Ven. 17-02", "Sam. 18-02", "Dim. 19-02"]),
+])
+def test_get_previous_week_schedule(start_date_str, expected_output):
+    """
+    Tests the get_previous_week_schedule function to check if the function returns the 7-day before the date given.
+
+    Args:
+        start_date_str (str): The start date in string format.
+        expected_output (Any): The expected output of the function.
+
+    Asserts:
+        The function's output matches the expected output.
+    """
+    assert get_previous_week_schedule(start_date_str) == expected_output

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -166,3 +166,29 @@ def test_generate_planning_route_missing_data(client):
         "/generate-planning", data=json.dumps({}), content_type="application/json"
     )
     assert response.status_code == 400  # Checks that missing data is managed
+
+
+def test_generate_planning_route_invalid_agent(client):
+    data = {
+        "start_date": "2023-01-01",
+        "end_date": "2023-01-07",
+        "initial_shifts": {"InvalidAgent": [("Sam. 31-12", "Jour")]}
+    }
+    response = client.post(
+        "/generate-planning", data=json.dumps(data), content_type="application/json"
+    )
+    assert response.status_code == 400
+    assert response.json == {"error": "Invalid agent: InvalidAgent"}
+
+def test_generate_planning_route_invalid_vacation(client):
+    data = {
+        "start_date": "2023-01-01",
+        "end_date": "2023-01-07",
+        "initial_shifts": {"Agent1": [("Sam. 31-12", "InvalidVacation")]}
+    }
+    response = client.post(
+        "/generate-planning", data=json.dumps(data), content_type="application/json"
+    )
+    assert response.status_code == 400
+    assert response.json == {"error": "Invalid vacation: InvalidVacation"}
+

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -169,6 +169,20 @@ def test_generate_planning_route_missing_data(client):
 
 
 def test_generate_planning_route_invalid_agent(client):
+    """
+    Test the /generate-planning route with an invalid agent.
+
+    This test sends a POST request to the /generate-planning endpoint with a payload
+    containing an invalid agent name. It verifies that the response status code is 400
+    and that the response JSON contains an error message indicating the invalid agent.
+
+    Args:
+        client (FlaskClient): The test client used to make requests to the Flask application.
+
+    Asserts:
+        - The response status code is 400.
+        - The response JSON contains the error message "Invalid agent: InvalidAgent".
+    """
     data = {
         "start_date": "2023-01-01",
         "end_date": "2023-01-07",
@@ -181,6 +195,21 @@ def test_generate_planning_route_invalid_agent(client):
     assert response.json == {"error": "Invalid agent: InvalidAgent"}
 
 def test_generate_planning_route_invalid_vacation(client):
+    """
+    Test the /generate-planning route with an invalid vacation entry.
+
+    This test sends a POST request to the /generate-planning endpoint with
+    a payload containing an invalid vacation entry for an agent. It verifies
+    that the response status code is 400 (Bad Request) and that the response
+    JSON contains the appropriate error message indicating the invalid vacation.
+
+    Args:
+        client (FlaskClient): The test client used to make requests to the Flask application.
+
+    Asserts:
+        - The response status code is 400.
+        - The response JSON contains the error message "Invalid vacation: InvalidVacation".
+    """
     data = {
         "start_date": "2023-01-01",
         "end_date": "2023-01-07",


### PR DESCRIPTION
This pull request includes several changes to the `backend/tests/test_constraints.py` and `backend/tests/test_helpers.py` files to enhance the test coverage and functionality of the `generate_planning` function. The most important changes include adding a previous week's schedule to the test data, updating test cases to include this new data, and adding new tests for initial shifts and invalid data scenarios.

Enhancements to test data:

* [`backend/tests/test_constraints.py`](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L67-R76): Added `previous_week_schedule` to the return value of `setup_correct_data()` and updated all relevant test cases to include this new parameter. [[1]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L67-R76) [[2]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5R173-R182) [[3]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5R192-R200) [[4]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L198-R217) [[5]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L222-R241) [[6]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L235-R267) [[7]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5L269-R303)

New tests for additional scenarios:

* [`backend/tests/test_helpers.py`](diffhunk://#diff-ec882d2eea05987eb400184eeeac77abcfcd97a9b814f2539f671acba5b90e03R664-R699): Added a new test function `test_get_previous_week_schedule` with multiple test cases to validate the `get_previous_week_schedule` function.
* [`backend/tests/test_routes.py`](diffhunk://#diff-1c56de128ee5f4a5004428585103775b924199c7fdb3dcd8622b05cd6b9ac334R169-R223): Added new test functions `test_generate_planning_route_invalid_agent` and `test_generate_planning_route_invalid_vacation` to check the handling of invalid agent names and vacation entries in the `/generate-planning` route.

These changes improve the robustness of the test suite by ensuring that the `generate_planning` function handles various edge cases and additional input data correctly.