### PR TITLE
160-frontend---display-the-previous-week-in-the-schedule

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -141,11 +141,38 @@ def is_valid_date(date_str):
         return False
 
 
+@app.route("/previous-week-schedule", methods=["POST"])
+def compute_previous_week_schedule():
+    try:
+        # Check if the start_date is present in the query
+        if "start_date" not in request.json:
+            return jsonify({"error": "Missing start_date"}), 400
+        # Check that the date is valid
+        if not is_valid_date(request.json["start_date"]):
+            return jsonify({"error": "Invalid date format"}), 400
+
+        start_date = request.json["start_date"]
+        previous_week_schedule = get_previous_week_schedule(start_date)
+        
+        agents = config["agents"]
+
+        return jsonify({
+            "previous_week_schedule": previous_week_schedule,
+            "agents": agents
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
 def get_previous_week_schedule(start_date_str):
     # Configuer le local pour utiliser les jours de la semaine en français
     locale.setlocale(locale.LC_TIME, "fr_FR.UTF-8")
-    # Convertir la chaine en objet datetime
-    start_date = datetime.strptime(start_date_str, "%Y-%m-%d")  # Format date / ISO 8601
+    
+    try:
+        # Convertir la chaine en objet datetime
+        start_date = datetime.strptime(start_date_str, "%Y-%m-%d")  # Format date / ISO 8601
+    except ValueError as e:
+        raise ValueError("Invalid date format. Use YYYY-MM-DD.") from e
     
     previous_week_start = start_date - timedelta(days=7)
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -170,12 +170,28 @@ export default {
       }
     },
     async generatePlanning() {
+      const payload = {
+        start_date: this.startDate,
+        end_date: this.endDate
+      };
+
+      // Si le mode de continuité est activé, ajouter les données de la semaine précédente
+      if (this.isContinuityMode) {
+        payload.initial_shifts = {};
+        for (const agent in this.selectedShifts) {
+          payload.initial_shifts[agent] = [];
+          for (const day in this.selectedShifts[agent]) {
+            if (this.selectedShifts[agent][day]) {
+            payload.initial_shifts[agent].push([day, this.selectedShifts[agent][day]]);
+            }
+          }
+        }
+      }
+
       try {
         // Envoyer la requête à Flask pour générer le planning avec les dates de début et de fin
-        const response = await axios.post('http://127.0.0.1:5000/generate-planning', {
-          start_date: this.startDate,
-          end_date: this.endDate
-        });
+        const response = await axios.post('http://127.0.0.1:5000/generate-planning', payload);
+        
         this.planningResult = response.data.planning; // Stocker les données dans planningResult
         this.vacationDurations = response.data.vacation_durations; // Stocker les durées de vacation
         this.weekSchedule = response.data.week_schedule; // Stocker le calendrier de la période

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,32 @@
       </label>
     </div>
 
+    <!-- Tableau des Shifts Initiaux (uniquement si mode continuité activé) -->
+    <div v-if="isContinuityMode && previousWeekSchedule.length">
+      <h3>Semaine de transition</h3>
+      <table class="transition-table">
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th v-for="day in previousWeekSchedule" :key="day">{{ day }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="agent in agents" :key="agent.name">
+            <td>{{ agent.name }}</td>
+            <td v-for="day in previousWeekSchedule" :key="day">
+              <select v-model="selectedShifts[agent.name][day]">
+                <option value="">-</option>
+                <option v-for="vacation in vacations" :key="vacation" :value="vacation">
+                  {{ vacation }}
+                </option>
+              </select>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
     <div>
       <button @click="generatePlanning">Générer le planning</button>
     </div>
@@ -84,10 +110,65 @@ export default {
       dayOffFromConfig: null, // Initialement, aucun jour de congé n'est défini, sera rempli à partir de la configuration
       trainingFromConfig: null, // Initialement, aucune formation n'est définie, sera rempli à partir de la configuration
       errorMessage: null, // Initially, no error is defined, will be filled after the call to the API
+      infoMessage: null, // Initially, no information message is defined, will be filled in after the call to the API
       isContinuityMode: false, // Set generation mode to false
+      previousWeekSchedule: [], // Set the previous week schedule to an empty array, will be filled after the call to the API
+      agents: [], // Set the agents to an empty array, will be filled after the call to the API
+      vacations: ['Jour', 'Nuit', 'CDP'], // Set the vacation types
+      selectedShifts: {} // Set the selected shifts to an empty object
     };
   },
+  watch: {
+    // When user changes the continuity mode to true, fetch the previous week schedule
+    isContinuityMode(newValue) {
+      if (newValue) {
+        this.fetchPreviousWeekSchedule();
+      }
+    }
+  },
   methods: {
+    // Récupérer la semaine précédente via l'API
+    async fetchPreviousWeekSchedule() {
+      if (!this.startDate) {
+        alert("Veuillez sélectionner une période avant de continuer.");
+        return;
+      }
+      try {
+        const response = await axios.post("http://127.0.0.1:5000/previous-week-schedule", {
+          start_date: this.startDate
+        });
+        console.log("Data de Fetch :", response.data);
+        this.previousWeekSchedule = response.data.previous_week_schedule;
+        this.agents = response.data.agents || []; // Si agents est undefined, on le remplace par un tableau vide pour éviter l’erreur.
+
+        // Si agents est vide ou mal formaté, on affiche un message d’erreur dans la console et on stoppe l'exécution.
+        if (!Array.isArray(this.agents) || this.agents.length === 0) {
+          console.error("Erreur : Liste des agents vide ou mal définie", this.agents);
+          return;
+        }
+
+        // Si previousWeekSchedule est vide ou mal formaté, on affiche un message d’erreur dans la console et on stoppe l'exécution.
+        if (!Array.isArray(this.previousWeekSchedule) || this.previousWeekSchedule.length === 0) {
+          console.error("Erreur : Semaine précédente vide ou mal définie", this.previousWeekSchedule);
+          return;
+        }
+
+        // Initialiser les shifts sélectionnés uniquement si les données sont récupérées avec succès
+        this.selectedShifts = {};
+        this.agents.forEach(agent => {
+          if (!agent.name) { //Si un agent est mal défini, on affiche un avertissement et on évite une potentielle erreur.
+            console.warn("Agent sans nom détecté, vérifie le backend", agent);
+            return;
+          }
+          this.selectedShifts[agent.name] = {};
+          this.previousWeekSchedule.forEach(day => {
+            this.selectedShifts[agent.name][day] = "";
+          });
+        });
+      } catch (error) {
+        console.error("Erreur lors de la récupération des données :", error);
+      }
+    },
     async generatePlanning() {
       try {
         // Envoyer la requête à Flask pour générer le planning avec les dates de début et de fin
@@ -180,4 +261,22 @@ button:hover {
   margin-bottom: 20px;
 }
 
+/* Tableau de transition */
+.transition-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 15px;
+}
+
+.transition-table th, .transition-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: center;
+}
+
+/* Sélecteurs de vacation */
+.transition-table select {
+  width: 100%;
+  padding: 5px;
+}
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,18 @@
       <label for="end">Date de fin :</label>
       <input type="date" id="end" name="end" v-model="endDate" />
     </div>
+    <!-- Sélecteur de mode -->
+    <div class="generation-mode">
+      <label>
+        <input type="radio" v-model="isContinuityMode" :value="false" />
+        Nouvelle génération
+      </label>
+      <label>
+        <input type="radio" v-model="isContinuityMode" :value="true" />
+        Génération avec continuité
+      </label>
+    </div>
+
     <div>
       <button @click="generatePlanning">Générer le planning</button>
     </div>
@@ -72,7 +84,7 @@ export default {
       dayOffFromConfig: null, // Initialement, aucun jour de congé n'est défini, sera rempli à partir de la configuration
       trainingFromConfig: null, // Initialement, aucune formation n'est définie, sera rempli à partir de la configuration
       errorMessage: null, // Initially, no error is defined, will be filled after the call to the API
-      infoMessage: null // Initially, no information message is defined, will be filled in after the call to the API
+      isContinuityMode: false, // Set generation mode to false
     };
   },
   methods: {
@@ -160,4 +172,12 @@ button:hover {
   font-size: 16px;
   font-weight: bold;
 }
+
+/* Style du toggle de sélection de mode */
+.generation-mode {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
 </style>


### PR DESCRIPTION
This pull request introduces a new feature for generating schedules with continuity mode and includes significant changes to both the backend and frontend components. The most important changes are grouped by theme below:

### Backend Enhancements:

* Added a new endpoint `compute_previous_week_schedule` to handle POST requests and return the previous week's schedule and agents. (`backend/app.py`)
* Updated `get_previous_week_schedule` to raise a `ValueError` if the date format is invalid. (`backend/app.py`)

### Frontend Enhancements:

* Introduced a mode selector for schedule generation, allowing users to choose between a new generation and continuity mode. (`frontend/src/App.vue`)
* Added a table to display initial shifts for agents when continuity mode is enabled. (`frontend/src/App.vue`)
* Implemented `fetchPreviousWeekSchedule` method to retrieve the previous week's schedule and update the component's state accordingly. (`frontend/src/App.vue`)

### Styling Updates:

* Added styles for the mode selector and the transition table to enhance the user interface. (`frontend/src/App.vue`)

Close #160, close #161, close #162, close #163