### PR TITLE
frontend: improve planning table reliability and add year-boundary regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added frontend API client utility with centralized base URL support through `VUE_APP_API_BASE_URL`.
+- Added frontend tests for API error normalization and year-boundary leave rendering in `PlanningTable`.
+- Added backend route tests for invalid/missing JSON payloads and invalid date ranges.
+
+### Changed
+
+- Hardened backend route payload validation (`/generate-planning`, `/previous-week-schedule`) with defensive JSON/object checks.
+- Reworked backend day label formatting to be locale-independent across platforms.
+- Cleaned solver objective setup to use a single optimization objective and added structured solver diagnostics logs.
+- Improved frontend generation UX with explicit loading state and safer error handling for transport/API failures.
+
+### Removed
+
+- Removed `frontend/src/components/ConfigComponent.vue` debug component from the main application flow.
+
 ## [0.7.8] - 2026-03-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Ensure the following tools are installed:
    npm run serve
    ```
 
+   Optional API base URL override (default: `http://127.0.0.1:5000`):
+
+   ```bash
+   # Windows PowerShell
+   $env:VUE_APP_API_BASE_URL="http://127.0.0.1:5000"
+   npm run serve
+   ```
+
 5. 🔍 Access the application at `http://localhost:8080` and start scheduling!
 
 ---

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -1,283 +1,276 @@
-<template>
-    <div>
-      <h1>Planning des Vacations</h1>
+﻿<template>
+  <div>
+    <h1>Planning des Vacations</h1>
 
-      <!-- Boucle pour chaque mois pour afficher un tableau par mois -->
-      <div v-for="(monthDays, monthKey) in splitByMonth(weekSchedule)" :key="monthKey" class="month-table">
-        <h2>{{ formatMonthTitle(monthKey) }}</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Agent</th>
-              <th v-for="day in monthDays" :key="day">{{ day }}</th>
-              <th>Total Vacations</th> <!-- Ajouter une colonne pour afficher le nombre de vacations -->
-              <th>Total Heures</th> <!-- Ajouter une colonne pour afficher le total des heures -->
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(agent, index) in Object.keys(planning)" :key="index">
-              <td>{{ agent }}</td>
-              <td v-for="day in monthDays" :key="day" :style="{ backgroundColor: getColumnColor(agent, day)}">
-                <!-- On affiche la vacation de cet agent ce jour-là -->
-                {{ getVacationForAgent(agent, day) || '//' }}
-              </td>
-              <td>{{ calculateNumberShifts(agent, monthDays) }}</td> <!-- Afficher le nombre de vacations pour cet agent -->
-              <td>{{ calculateTotalHours(agent, monthDays) }} h</td> <!-- Afficher le total des heures pour cet agent -->
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div
+      v-for="(monthDays, monthKey) in splitByMonth(weekSchedule)"
+      :key="monthKey"
+      class="month-table"
+    >
+      <h2>{{ formatMonthTitle(monthKey) }}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th v-for="day in monthDays" :key="day">{{ day }}</th>
+            <th>Total Vacations</th>
+            <th>Total Heures</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(agent, index) in Object.keys(planning)" :key="index">
+            <td>{{ agent }}</td>
+            <td v-for="day in monthDays" :key="day" :style="{ backgroundColor: getColumnColor(agent, day) }">
+              {{ getVacationForAgent(agent, day) || '//' }}
+            </td>
+            <td>{{ calculateNumberShifts(agent, monthDays) }}</td>
+            <td>{{ calculateTotalHours(agent, monthDays) }} h</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-  </template>
-  
-  <script>
-  export default {
-    props: {
-      planning: {
-        type: Object,
-        required: true
-      },
-      weekSchedule: {
-        type: Array,
-        required: true
-      },
-      vacationDurations: {
-        type: Object,
-        required: true
-      },
-      vacationColors: {
-        type: Object,
-        required: true
-      },
-      holidays: {
-        type: Array,
-        required: true
-      },
-      unavailable: {
-        type: Object,
-        required: true
-      },
-      dayOff: {
-        type: Object,
-        required: true
-      },
-      training: {
-        type: Object,
-        required: true
-      }
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    planning: {
+      type: Object,
+      required: true
     },
-    methods: {
-      splitByMonth(weekSchedule) {
-        if (!Array.isArray(weekSchedule)) {
-          console.warn("weekSchedule is not a valid array:", weekSchedule);
-          return {}; // Retourner un objet vide si ce n'est pas un tableau
-        }
-        return weekSchedule.reduce((months, day) => {
-          const monthKey = day.slice(8, 10); // Extraire le mois en abréviation (ex. Jan, Feb, etc.)
-          if (!months[monthKey]) {
-            months[monthKey] = [];
-          }
-          months[monthKey].push(day);
-          return months;
-        }, {});
-      },
-      formatMonthTitle(month) {
-        const monthMap = {
-                "01": "Janvier", "02": "Février", "03": "Mars", "04": "Avril", "05": "Mai", "06": "Juin",
-                "07": "Juillet", "08": "Août", "09": "Septembre", "10": "Octobre", "11": "Novembre", "12": "Décembre"
-            };
-        return monthMap[month] || month;
-      },
-      getVacationForAgent(agent, day) {
-        // Vérifie si le jour est un jour de formation
-        if (this.isTrainingDay(agent, day)) {
-          return "For."; // Retourner "Formation" si c'est un jour de formation
-        }
-        // Vérifie si le jour est un jour de congé
-        if (this.isVacationDay(agent, day)) {
-          return "Con."; // Retourner "Congé" si c'est un jour de congé
-        }
-        // Vérifie d'abord si l'agent est indisponible
-        if (this.isUnavailable(agent, day)) {
-          return "Ind."; // Retourner "Indisponible" si l'agent est indisponible
-        }
-        const vacations = this.planning[agent]
-
-        if (Array.isArray(vacations)) {
-          // Si c'est un tableau, utilisez .find()
-          const vacationForDay = vacations.find(vac => vac[0] === day);
-          return vacationForDay ? vacationForDay[1] : null;
-        } else if (typeof vacations === 'object') {
-          /// Si c'est un objet, utilisez Object.entries() pour parcourir les clés/valeurs
-          for (const [vacationDay, vacation] of Object.entries(vacations)) {
-            if (vacationDay === day) {
-              return vacation;
-            }
-          }
-          return null;
-        }
-      },
-      isVacationDay(agent, day) { // Vérifie si un jour est un jour de congé
-        // Vérifie si les jours de congé existent pour cet agent
-        if (!this.dayOff || !this.dayOff[agent]) {
-          console.error(`Jour de congé pour l'agent ${agent} non défini.`, this.dayOff);
-          return false; // Retourner false si aucun jour de congé n'est défini
-        }
-
-        // On suppose que this.dayOff[agent] est un tableau de périodes, chaque période étant un tableau [dateDebut, dateFin]
-        const vacations = this.dayOff[agent] || {}; // Obtenir les jours de congé pour cet agent
-        const dayPart = day.split(" ")[1]; // Extraire la partie date (dd-mm)
-
-        // Ajouter une année fictive pour les comparaisons
-        const referenceYear = new Date().getFullYear();
-        const currentDate = new Date(`${referenceYear}-${dayPart.slice(3, 5)}-${dayPart.slice(0, 2)}`); // Convertir la date actuelle au format YYYY-mm-dd
-
-        // Itérer sur chaque période de congés pour vérifier que le jour courant y est compris
-        for (let i = 0; i < vacations.length; i++) {
-          const period = vacations[i];
-          if (!period || period.length < 2) continue; // Ignorer les périodes invalides
-
-          // Convertir les dates de début et de fin de la période au format YYYY-mm-dd
-          const vacationStartDate = new Date(`${period[0].slice(6, 10)}-${period[0].slice(3, 5)}-${period[0].slice(0, 2)}`);
-          const vacationEndDate = new Date(`${period[1].slice(6, 10)}-${period[1].slice(3, 5)}-${period[1].slice(0, 2)}`);
-          
-          // Vérifier si la date de début est supérieure à la date de fin (vacances qui chevauchent l'année)
-          if (vacationStartDate > vacationEndDate) {
-            // Si la date de début est supérieure à la date de fin, c'est un congé qui chevauche l'année
-            if (currentDate >= vacationStartDate || currentDate <= vacationEndDate) {
-              return true; // Retourner true si le jour est dans la période de congé
-            }
-          } else {
-            if (vacationStartDate <= currentDate && currentDate <= vacationEndDate) {
-              return true; // Retourner true si le jour est dans la période de congé
-            }
-          }
-        }
-        return false; // Retourner false si le jour n'est pas un jour de congé
-      },
-      isUnavailable(agent, day) { // Vérifie si un jour est une indisponibilité
-        // Vérifie si les indisponibilités exsitent pour cet agent
-        if (!this.unavailable || !this.unavailable[agent]) {
-          console.error(`Indisponibilités pour l'agent ${agent} non définies.`, this.unavailable);
-          return false; // Retourner false si aucune indisponibilité n'est définie
-        }
-
-        const unavailableDays = this.unavailable[agent] || [];
-        const datePart = day.split(" ")[1]; // Extraire la partie de la date dd-mm
-
-        // Comparer uniquement dd-mm des indisponiblités
-        const formatedUnavailableDays = unavailableDays.map(date => date.slice(0, 5));  // Extraire uniquement dd-mm
-        return formatedUnavailableDays.includes(datePart); // Retourner true si le jour est indisponible
-      },
-      //   // Chercher la vacation de cet agent pour ce jour
-      //   const vacationForDay = this.planning[agent].find(vac => vac[0] === day);
-      //   return vacationForDay ? vacationForDay[1] : null; // Retourne la vacation ou null si pas de vacation
-      // },
-      getVacationColor(agent, day) {
-        // Obtenir la vacation pour cet agent
-        const vacation = this.getVacationForAgent(agent, day);
-        // Retourner la couleur correspondante
-        return vacation ? this.vacationColors[vacation] : "white";  // Blanc si pas de vacation
-      },
-      // Vérifie si le jour est un jour férié
-      isHoliday(day) {
-        if (this.holidays && Array.isArray(this.holidays)) {
-          // Extrait la partie de la date dd-mm de la chaine
-          const datePart = day.split(" ")[1]; // Extraire la partie de la date
-          return this.holidays.includes(datePart); // Retourner true si le jour est un jour férié dans la liste
-        }
-        return false; // Retourner false si la liste des jours fériés n'est pas définie
-      },
-      // Vérifie si le jour est un jour de formation
-      isTrainingDay(agent, day) {
-        if (!this.training || !this.training[agent]) {
-          console.error(`Formation pour l'agent ${agent} non définie.`, this.training);
-          return false; // Retourner false si aucune formation n'est définie
-        }
-        const trainingDays = this.training[agent] || [];
-        const datePart = day.split(" ")[1]; // Extraire la partie de la date dd-mm
-
-        // Comparer uniquement dd-mm des jours de formation
-        const formatedTrainingDays = trainingDays.map(date => date.slice(0, 5));  // Extraire uniquement dd-mm
-        return formatedTrainingDays.includes(datePart); // Retourner true si le jour est un jour de formation
-      },
-      getColumnColor(agent, day) {
-        // Vérifier d'abord si c'est un jour de congé
-        if (this.isVacationDay(agent, day)) {
-          return "#f2cb05"; // Jaune pour les jours de congé
-        }
-
-        // Vérifier d'abord si l'agent est indisponible
-        if (this.isUnavailable(agent, day)) {
-            return "#f2cb05"; // Jaune pour les jours indisponibles
-        }
-
-        // Vérifier si c'est un jour de formation
-        if (this.isTrainingDay(agent, day)) {
-          return "#D93030"; // Rouge pour les jours de formation
-        }
-        
-        // Enfin retourner la couleur de la vacation si elle existe
-        const vacationColor = this.getVacationColor(agent, day);
-        if (vacationColor && vacationColor !== "white") {
-          return vacationColor; // Retourner la couleur de la vacation
-        }
-
-        // Vérifier si c'est un jour férié ou un week-end
-        if (this.isHoliday(day) || day.includes("Sam") || day.includes("Dim")) {
-            return "#dedede"; // Gris pour les jours fériés et les week-ends
-          }
-
-        return "white"; // Retourner blanc par défaut
-      },
-      calculateTotalHours(agent, days) {
-        // // Vérifier si this.planning[agent] est un tableau
-        // if (!Array.isArray(this.planning[agent])) {
-        //   console.error(`Planning pour l'agent ${agent} n'est pas un tableau.`, this.planning[agent]);
-        //   return 0; // Retourner 0 si ce n'est pas un tableau
-        // }
-        // // Calculer le total des heures pour cet agent en utilisant vacationDurations
-        // return this.planning[agent].reduce((total, vac) => {
-        //   const vacation = vac[1]; // Obtenir la vacation
-        //   return total + (this.vacationDurations[vacation] || 0); // Ajouter la durée de la vacation
-        // }, 0);  // Commencer à 0
-        return days.reduce((total, day) => {
-                const vacation = this.getVacationForAgent(agent, day);
-                return total + (this.vacationDurations[vacation] || 0);
-            }, 0);
-      },
-      calculateNumberShifts(agent, days) {
-        // // Vérifier si this.planning[agent] est un tableau
-        // if (!Array.isArray(this.planning[agent])) {
-        //   console.error(`Planning pour l'agent ${agent} n'est pas un tableau.`, this.planning[agent]);
-        //   return 0; // Retourner 0 si ce n'est pas un tableau
-        // }
-        // // Retourner le nombre de vacations pour cet agent
-        // return this.planning[agent].length;
-        return days.filter(day => this.getVacationForAgent(agent, day)).length;
-      }
+    weekSchedule: {
+      type: Array,
+      required: true
+    },
+    vacationDurations: {
+      type: Object,
+      required: true
+    },
+    vacationColors: {
+      type: Object,
+      required: true
+    },
+    holidays: {
+      type: Array,
+      required: true
+    },
+    unavailable: {
+      type: Object,
+      required: true
+    },
+    dayOff: {
+      type: Object,
+      required: true
+    },
+    training: {
+      type: Object,
+      required: true
     }
-  };
-  </script>
-  
-  <style scoped>
-  .month-table {
-    margin-bottom: 20px;
-  }
+  },
+  computed: {
+    planningLookup() {
+      const lookup = {};
+      Object.entries(this.planning || {}).forEach(([agent, vacations]) => {
+        lookup[agent] = {};
+        if (Array.isArray(vacations)) {
+          vacations.forEach((entry) => {
+            if (Array.isArray(entry) && entry.length === 2) {
+              lookup[agent][entry[0]] = entry[1];
+            }
+          });
+        } else if (vacations && typeof vacations === 'object') {
+          Object.entries(vacations).forEach(([day, vacation]) => {
+            lookup[agent][day] = vacation;
+          });
+        }
+      });
+      return lookup;
+    }
+  },
+  methods: {
+    splitByMonth(weekSchedule) {
+      if (!Array.isArray(weekSchedule)) {
+        return {};
+      }
+      return weekSchedule.reduce((months, day) => {
+        const dayPart = this.getDayPart(day);
+        const monthKey = dayPart ? dayPart.split('-')[1] : '??';
+        if (!months[monthKey]) {
+          months[monthKey] = [];
+        }
+        months[monthKey].push(day);
+        return months;
+      }, {});
+    },
+    formatMonthTitle(month) {
+      const monthMap = {
+        '01': 'Janvier',
+        '02': 'Février',
+        '03': 'Mars',
+        '04': 'Avril',
+        '05': 'Mai',
+        '06': 'Juin',
+        '07': 'Juillet',
+        '08': 'Août',
+        '09': 'Septembre',
+        '10': 'Octobre',
+        '11': 'Novembre',
+        '12': 'Décembre'
+      };
+      return monthMap[month] || month;
+    },
+    getDayPart(dayLabel) {
+      const parts = (dayLabel || '').split(' ');
+      return parts.length > 1 ? parts[1] : null;
+    },
+    isWeekendLabel(dayLabel) {
+      return dayLabel.includes('Sam') || dayLabel.includes('Dim');
+    },
+    parseConfigDate(dateStr) {
+      if (!dateStr || typeof dateStr !== 'string' || dateStr.length !== 10) {
+        return null;
+      }
+      const day = Number(dateStr.slice(0, 2));
+      const month = Number(dateStr.slice(3, 5));
+      const year = Number(dateStr.slice(6, 10));
+      const date = new Date(year, month - 1, day);
+      if (
+        Number.isNaN(date.getTime()) ||
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+      ) {
+        return null;
+      }
+      return date;
+    },
+    formatDayMonth(date) {
+      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      return `${day}-${month}`;
+    },
+    getVacationForAgent(agent, day) {
+      if (this.isTrainingDay(agent, day)) {
+        return 'For.';
+      }
+      if (this.isVacationDay(agent, day)) {
+        return 'Con.';
+      }
+      if (this.isUnavailable(agent, day)) {
+        return 'Ind.';
+      }
+      return this.planningLookup?.[agent]?.[day] || null;
+    },
+    isVacationDay(agent, day) {
+      const vacations = this.dayOff?.[agent] || [];
+      const dayPart = this.getDayPart(day);
+      if (!dayPart || this.isWeekendLabel(day)) {
+        return false;
+      }
 
-  table {
-    width: 100%;
-    border-collapse: collapse;
+      for (let i = 0; i < vacations.length; i += 1) {
+        const period = vacations[i];
+        if (!period || period.length < 2) {
+          continue;
+        }
+        const vacationStartDate = this.parseConfigDate(period[0]);
+        const vacationEndDate = this.parseConfigDate(period[1]);
+        if (!vacationStartDate || !vacationEndDate || vacationStartDate > vacationEndDate) {
+          continue;
+        }
+
+        const cursor = new Date(vacationStartDate);
+        while (cursor <= vacationEndDate) {
+          if (this.formatDayMonth(cursor) === dayPart) {
+            return true;
+          }
+          cursor.setDate(cursor.getDate() + 1);
+        }
+      }
+      return false;
+    },
+    isUnavailable(agent, day) {
+      const unavailableDays = this.unavailable?.[agent] || [];
+      const dayPart = this.getDayPart(day);
+      if (!dayPart) {
+        return false;
+      }
+      const formattedUnavailableDays = unavailableDays.map((date) => date.slice(0, 5));
+      return formattedUnavailableDays.includes(dayPart);
+    },
+    getVacationColor(agent, day) {
+      const vacation = this.getVacationForAgent(agent, day);
+      return vacation ? this.vacationColors[vacation] : 'white';
+    },
+    isHoliday(day) {
+      if (this.holidays && Array.isArray(this.holidays)) {
+        const datePart = this.getDayPart(day);
+        return datePart ? this.holidays.includes(datePart) : false;
+      }
+      return false;
+    },
+    isTrainingDay(agent, day) {
+      const trainingDays = this.training?.[agent] || [];
+      const datePart = this.getDayPart(day);
+      if (!datePart) {
+        return false;
+      }
+      const formattedTrainingDays = trainingDays.map((date) => date.slice(0, 5));
+      return formattedTrainingDays.includes(datePart);
+    },
+    getColumnColor(agent, day) {
+      if (this.isVacationDay(agent, day)) {
+        return '#f2cb05';
+      }
+      if (this.isUnavailable(agent, day)) {
+        return '#f2cb05';
+      }
+      if (this.isTrainingDay(agent, day)) {
+        return '#D93030';
+      }
+
+      const vacationColor = this.getVacationColor(agent, day);
+      if (vacationColor && vacationColor !== 'white') {
+        return vacationColor;
+      }
+
+      if (this.isHoliday(day) || this.isWeekendLabel(day)) {
+        return '#dedede';
+      }
+      return 'white';
+    },
+    calculateTotalHours(agent, days) {
+      return days.reduce((total, day) => {
+        const vacation = this.getVacationForAgent(agent, day);
+        return total + (this.vacationDurations[vacation] || 0);
+      }, 0);
+    },
+    calculateNumberShifts(agent, days) {
+      return days.filter((day) => this.getVacationForAgent(agent, day)).length;
+    }
   }
-  
-  th, td {
-    border: 1px solid black;
-    padding: 8px;
-    text-align: center;
-  }
-  
-  th {
-    background-color: #dedede
-  }
-  </style>
-  
+};
+</script>
+
+<style scoped>
+.month-table {
+  margin-bottom: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid black;
+  padding: 8px;
+  text-align: center;
+}
+
+th {
+  background-color: #dedede;
+}
+</style>

--- a/frontend/tests/PlanningTable.spec.js
+++ b/frontend/tests/PlanningTable.spec.js
@@ -34,4 +34,37 @@ describe('PlanningTable.vue', () => {
     expect(wrapper.text()).toContain('Jour');
     expect(wrapper.text()).toContain('8 h');
   });
+
+  it('marks leave correctly across year boundary using configured period years', () => {
+    const wrapper = shallowMount(PlanningTable, {
+      props: {
+        planning: {
+          Agent1: [['Mer. 31-12', 'Jour'], ['Jeu. 01-01', 'Nuit']],
+        },
+        weekSchedule: ['Mer. 31-12', 'Jeu. 01-01'],
+        vacationDurations: {
+          Jour: 8,
+          Nuit: 8,
+        },
+        vacationColors: {
+          Jour: '#75FA79',
+          Nuit: '#9175FA',
+        },
+        holidays: [],
+        unavailable: {
+          Agent1: [],
+        },
+        dayOff: {
+          Agent1: [['31-12-2025', '02-01-2026']],
+        },
+        training: {
+          Agent1: [],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Con.');
+    expect(wrapper.text()).not.toContain('Jour');
+    expect(wrapper.text()).not.toContain('Nuit');
+  });
 });


### PR DESCRIPTION
## Summary
Improve PlanningTable reliability and performance, especially for year-boundary leave periods, and finalize related documentation updates.

## Changes
- Refactored PlanningTable data access with pre-indexed planning lookups.
- Fixed leave-day detection logic to avoid dependence on system current year.
- Reduced noisy console-error behavior with safer fallbacks.
- Added year-boundary regression test for leave rendering.
- Updated changelog and README with API base URL migration note (`VUE_APP_API_BASE_URL`).

## Tests
- Frontend tests pass (`jest --runInBand`), including new year-boundary case.
- Backend tests still pass in CI.

## Why
This strengthens rendering correctness for real-world planning periods and improves maintainability/perf in table computations.
