### PR TITLE
Fix/leave dates year weekend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Refactored `backend/app.py` so API routes keep a stable `generate_planning(...)` facade while solver logic is delegated to `backend/solver/engine.py`.
 - Preserved API and configuration compatibility while splitting hard/soft/mixed constraints into dedicated modules.
 
+### Fixed
+
+- Fixed leave-year handling in the solver so leave periods are matched against full planning dates, preventing `dd-mm` collisions across years (for example 2025 leave affecting 2026 planning).
+- Fixed backend leave helper behavior to support year-safe date resolution with a planning start-date reference.
+- Fixed frontend leave rendering in `PlanningTable` to use full-date matching and correctly display `Con.` on weekend days included in leave periods.
+- Fixed frontend unavailable/training day matching in `PlanningTable` to use full dates consistently with backend config (`dd-mm-YYYY`).
+
 ## [0.7.9] - 2026-03-22
 
 ### Added

--- a/backend/app.py
+++ b/backend/app.py
@@ -150,6 +150,7 @@ def generate_planning_route():
             dayOff,
             previous_week_schedule,
             initial_shifts,
+            planning_start_date=start_date_str,
         )
 
         # If the result is a dict with an info key, return a 400 error.
@@ -332,7 +333,24 @@ def split_by_month_or_period(week_schedule):
     return periods
 
 
-def is_vacation_day(agent_name, day, dayOff):
+def _resolve_day_date_from_reference(day_part, reference_date):
+    day_value = int(day_part.split("-")[0])
+    month_value = int(day_part.split("-")[1])
+
+    candidates = []
+    for year in [reference_date.year - 1, reference_date.year, reference_date.year + 1]:
+        try:
+            candidates.append(datetime(year, month_value, day_value))
+        except ValueError:
+            continue
+
+    if not candidates:
+        return None
+
+    return min(candidates, key=lambda candidate: abs((candidate - reference_date).days))
+
+
+def is_vacation_day(agent_name, day, dayOff, planning_start_date=None):
     """Checks whether the day corresponds to leave for the agent,
     by checking all the periods defined in dayOff."""
     if agent_name in dayOff:
@@ -343,15 +361,22 @@ def is_vacation_day(agent_name, day, dayOff):
             vacation_start_date = datetime.strptime(vacation_start, "%d-%m-%Y")
             vacation_end_date = datetime.strptime(vacation_end, "%d-%m-%Y")
             try:
-                day_date = datetime.strptime(
-                    f"{day_part}-{vacation_start_date.year}", "%d-%m-%Y"
-                )
+                if planning_start_date is not None:
+                    if isinstance(planning_start_date, str):
+                        reference_date = datetime.strptime(planning_start_date, "%Y-%m-%d")
+                    else:
+                        reference_date = planning_start_date
+                    day_date = _resolve_day_date_from_reference(day_part, reference_date)
+                    if day_date is None:
+                        continue
+                else:
+                    day_date = datetime.strptime(
+                        f"{day_part}-{vacation_start_date.year}", "%d-%m-%Y"
+                    )
             except ValueError:
                 continue
             # Check if the day is between the holiday start and end dates
-            if vacation_start_date <= day_date <= vacation_end_date and not is_weekend(
-                day
-            ):
+            if vacation_start_date <= day_date <= vacation_end_date:
                 return True
     return False
 
@@ -401,7 +426,13 @@ def split_date_range_by_month(start: datetime, end: datetime) -> list:
 
 
 def generate_planning(
-    agents, vacations, week_schedule, dayOff, previous_week_schedule, initial_shifts
+    agents,
+    vacations,
+    week_schedule,
+    dayOff,
+    previous_week_schedule,
+    initial_shifts,
+    planning_start_date=None,
 ):
     # Public facade kept stable for existing route and tests.
     return generate_planning_engine(
@@ -412,6 +443,7 @@ def generate_planning(
         previous_week_schedule=previous_week_schedule,
         initial_shifts=initial_shifts,
         runtime_config=config,
+        planning_start_date=planning_start_date,
     )
 
 if __name__ == "__main__":

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -265,13 +265,15 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
             vacation_end = datetime.strptime(vac["end"], date_format_full)
 
             for day_str in ctx.week_schedule:
-                day_part = day_str.split(" ")[1]
-                try:
-                    day_date = datetime.strptime(
-                        f"{day_part}-{vacation_start.year}", date_format_full
-                    )
-                except ValueError:
-                    continue
+                day_date = ctx.day_dates.get(day_str)
+                if day_date is None:
+                    day_part = day_str.split(" ")[1]
+                    try:
+                        day_date = datetime.strptime(
+                            f"{day_part}-{vacation_start.year}", date_format_full
+                        )
+                    except ValueError:
+                        continue
 
                 if vacation_start <= day_date <= vacation_end:
                     for vacation in ctx.vacations:

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Dict, List, Tuple
 
 from ortools.sat.python import cp_model
@@ -55,10 +56,12 @@ class SolverContext:
     previous_week_schedule: List[str]
     initial_shifts: dict
     holidays: List[str]
+    planning_start_date: datetime | None = None
 
     weeks_split: List[List[str]] = field(default_factory=list)
     planning: Dict[Tuple[str, str, str], cp_model.IntVar] = field(default_factory=dict)
     leave_paid_hours_by_day: Dict[Tuple[str, str], int] = field(default_factory=dict)
+    day_dates: Dict[str, datetime] = field(default_factory=dict)
 
     jour_duration: int = 0
     nuit_duration: int = 0

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from ortools.sat.python import cp_model
 
 from .constraints import hard, mixed, soft
@@ -88,6 +90,30 @@ def _build_registry() -> ConstraintRegistry:
     return registry
 
 
+def _parse_iso_date(date_value):
+    if date_value is None:
+        return None
+    if isinstance(date_value, datetime):
+        return date_value
+    if isinstance(date_value, str):
+        return datetime.strptime(date_value, "%Y-%m-%d")
+    raise ValueError("planning_start_date must be YYYY-MM-DD or datetime")
+
+
+def _build_day_dates(ctx: SolverContext) -> None:
+    start_date = _parse_iso_date(ctx.planning_start_date)
+    if start_date is None:
+        return
+
+    for idx, day in enumerate(ctx.week_schedule):
+        ctx.day_dates[day] = start_date + timedelta(days=idx)
+
+    previous_start = start_date - timedelta(days=7)
+    for idx, day in enumerate(ctx.previous_week_schedule):
+        # Keep deterministic mapping for continuity constraints when previous week is provided.
+        ctx.day_dates.setdefault(day, previous_start + timedelta(days=idx))
+
+
 def _extract_solution(ctx: SolverContext, solver: cp_model.CpSolver):
     """
     Extracts the solution from the solver and returns it as a dictionary.
@@ -122,6 +148,7 @@ def generate_planning(
     previous_week_schedule,
     initial_shifts,
     runtime_config,
+    planning_start_date=None,
 ):
     """
     Generates a planning based on the given parameters.
@@ -154,11 +181,13 @@ def generate_planning(
         previous_week_schedule=previous_week_schedule,
         initial_shifts=initial_shifts,
         holidays=runtime_config["holidays"],
+        planning_start_date=planning_start_date,
     )
 
     _load_solver_settings(ctx)
     _load_shift_durations(ctx)
     ctx.weeks_split = split_into_weeks(ctx.week_schedule)
+    _build_day_dates(ctx)
     _build_planning_variables(ctx)
 
     registry = _build_registry()

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -555,6 +555,60 @@ def test_generate_planning_paid_leave_hours_balancing_regression():
 
     assert isinstance(result, dict)
     assert "info" not in result
+
+
+def test_generate_planning_ignores_leave_periods_from_other_years():
+    """
+    Regression test: leave periods from another year must not block a target planning year.
+
+    With exactly three agents and three shifts per day, blocking one agent on a day
+    makes the model infeasible. A 2025 leave must not affect a 2026 planning.
+    """
+
+    agents = [
+        {
+            "name": "Agent1",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour", "Nuit", "CDP"], "avoid": []},
+            "vacations": [{"start": "01-04-2025", "end": "03-04-2025"}],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Agent2",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour", "Nuit", "CDP"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Agent3",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour", "Nuit", "CDP"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+    ]
+    vacations = ["Jour", "Nuit", "CDP"]
+    week_schedule = ["Mar. 01-04", "Mer. 02-04", "Jeu. 03-04"]
+
+    result = generate_planning(
+        agents,
+        vacations,
+        week_schedule,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={},
+        planning_start_date="2026-04-01",
+    )
+
+    assert isinstance(result, dict)
+    assert "info" not in result
     
 ######
 # Test failed, possible bug in the generate_planning function (constraint not respected or too soft)

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -510,7 +510,7 @@ def test_is_vacation_day_false(day_off):
     """
 
     assert not is_vacation_day("Agent1", "Dim. 10-01", day_off)
-    assert not is_vacation_day("Agent2", "Dim. 22-01", day_off)
+    assert is_vacation_day("Agent2", "Dim. 22-01", day_off)
 
 
 def test_is_vacation_day_weekend(day_off):
@@ -524,8 +524,18 @@ def test_is_vacation_day_weekend(day_off):
         The function asserts that "Sam. 07-01" and "Dim. 15-01" are not vacation days for "Agent1" and "Agent2" respectively.
     """
 
-    assert not is_vacation_day("Agent1", "Sam. 07-01", day_off)
-    assert not is_vacation_day("Agent2", "Dim. 15-01", day_off)
+    assert is_vacation_day("Agent1", "Sam. 07-01", day_off)
+    assert is_vacation_day("Agent2", "Dim. 15-01", day_off)
+
+
+def test_is_vacation_day_uses_reference_year_when_provided():
+    day_off = {
+        "Agent1": [["01-04-2025", "03-04-2025"]],
+    }
+
+    assert not is_vacation_day(
+        "Agent1", "Mer. 02-04", day_off, planning_start_date="2026-04-01"
+    )
 
 
 def test_is_vacation_day_not_in_dayOff(day_off):

--- a/docs/solver-modularization.md
+++ b/docs/solver-modularization.md
@@ -30,6 +30,20 @@ Execution flow:
 6. Apply objective.
 7. Solve and extract result.
 
+## Date Handling Rules
+
+To avoid cross-year regressions in leave display and constraints, date comparisons must use full dates:
+
+- Backend solver:
+  - Build a day-label to full-date map from the planning start date.
+  - Compare leave periods against resolved full dates, not only `dd-mm`.
+- Frontend table:
+  - Resolve each displayed day label to a full date from `planningStartDate`.
+  - Match leave/unavailable/training entries using full config dates (`dd-mm-YYYY`).
+- Weekend policy:
+  - Leave periods include Saturday/Sunday for display (`Con.`) when those dates are in range.
+  - Paid-hours policy remains unchanged unless explicitly modified in solver rules.
+
 ## How To Add A Constraint
 
 1. Choose the right group (`hard`, `soft`, `mixed`).

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -70,6 +70,7 @@
         :unavailable="unavailableFromConfig"
         :dayOff="dayOffFromConfig"
         :training="trainingFromConfig"
+        :planningStartDate="startDate"
       />
     </div>
 

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -66,6 +66,11 @@ export default {
     training: {
       type: Object,
       required: true
+    },
+    planningStartDate: {
+      type: String,
+      required: false,
+      default: null
     }
   },
   computed: {
@@ -84,6 +89,22 @@ export default {
             lookup[agent][day] = vacation;
           });
         }
+      });
+      return lookup;
+    },
+    dayLabelDateLookup() {
+      const lookup = {};
+      if (!Array.isArray(this.weekSchedule) || this.weekSchedule.length === 0) {
+        return lookup;
+      }
+      const startDate = this.parseIsoDate(this.planningStartDate);
+      if (!startDate) {
+        return lookup;
+      }
+      this.weekSchedule.forEach((dayLabel, index) => {
+        const date = new Date(startDate);
+        date.setDate(date.getDate() + index);
+        lookup[dayLabel] = date;
       });
       return lookup;
     }
@@ -145,10 +166,45 @@ export default {
       }
       return date;
     },
+    parseIsoDate(dateStr) {
+      if (!dateStr || typeof dateStr !== 'string') {
+        return null;
+      }
+      const [yearRaw, monthRaw, dayRaw] = dateStr.split('-');
+      const year = Number(yearRaw);
+      const month = Number(monthRaw);
+      const day = Number(dayRaw);
+      const date = new Date(year, month - 1, day);
+      if (
+        Number.isNaN(date.getTime()) ||
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+      ) {
+        return null;
+      }
+      return date;
+    },
     formatDayMonth(date) {
       const day = String(date.getDate()).padStart(2, '0');
       const month = String(date.getMonth() + 1).padStart(2, '0');
       return `${day}-${month}`;
+    },
+    formatConfigDate(date) {
+      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const year = date.getFullYear();
+      return `${day}-${month}-${year}`;
+    },
+    resolveDayDate(dayLabel) {
+      return this.dayLabelDateLookup?.[dayLabel] || null;
+    },
+    dateNumber(date) {
+      return (
+        date.getFullYear() * 10000
+        + (date.getMonth() + 1) * 100
+        + date.getDate()
+      );
     },
     getVacationForAgent(agent, day) {
       if (this.isTrainingDay(agent, day)) {
@@ -164,10 +220,11 @@ export default {
     },
     isVacationDay(agent, day) {
       const vacations = this.dayOff?.[agent] || [];
-      const dayPart = this.getDayPart(day);
-      if (!dayPart || this.isWeekendLabel(day)) {
+      const dayDate = this.resolveDayDate(day);
+      if (!dayDate) {
         return false;
       }
+      const dayValue = this.dateNumber(dayDate);
 
       for (let i = 0; i < vacations.length; i += 1) {
         const period = vacations[i];
@@ -179,25 +236,22 @@ export default {
         if (!vacationStartDate || !vacationEndDate || vacationStartDate > vacationEndDate) {
           continue;
         }
-
-        const cursor = new Date(vacationStartDate);
-        while (cursor <= vacationEndDate) {
-          if (this.formatDayMonth(cursor) === dayPart) {
-            return true;
-          }
-          cursor.setDate(cursor.getDate() + 1);
+        const vacationStartValue = this.dateNumber(vacationStartDate);
+        const vacationEndValue = this.dateNumber(vacationEndDate);
+        if (vacationStartValue <= dayValue && dayValue <= vacationEndValue) {
+          return true;
         }
       }
       return false;
     },
     isUnavailable(agent, day) {
       const unavailableDays = this.unavailable?.[agent] || [];
-      const dayPart = this.getDayPart(day);
-      if (!dayPart) {
+      const dayDate = this.resolveDayDate(day);
+      if (!dayDate) {
         return false;
       }
-      const formattedUnavailableDays = unavailableDays.map((date) => date.slice(0, 5));
-      return formattedUnavailableDays.includes(dayPart);
+      const dayFull = this.formatConfigDate(dayDate);
+      return unavailableDays.includes(dayFull);
     },
     getVacationColor(agent, day) {
       const vacation = this.getVacationForAgent(agent, day);
@@ -212,12 +266,12 @@ export default {
     },
     isTrainingDay(agent, day) {
       const trainingDays = this.training?.[agent] || [];
-      const datePart = this.getDayPart(day);
-      if (!datePart) {
+      const dayDate = this.resolveDayDate(day);
+      if (!dayDate) {
         return false;
       }
-      const formattedTrainingDays = trainingDays.map((date) => date.slice(0, 5));
-      return formattedTrainingDays.includes(datePart);
+      const dayFull = this.formatConfigDate(dayDate);
+      return trainingDays.includes(dayFull);
     },
     getColumnColor(agent, day) {
       if (this.isVacationDay(agent, day)) {

--- a/frontend/tests/PlanningTable.spec.js
+++ b/frontend/tests/PlanningTable.spec.js
@@ -25,6 +25,7 @@ describe('PlanningTable.vue', () => {
         training: {
           Agent1: [],
         },
+        planningStartDate: '2026-11-01',
       },
     });
 
@@ -60,11 +61,82 @@ describe('PlanningTable.vue', () => {
         training: {
           Agent1: [],
         },
+        planningStartDate: '2025-12-31',
       },
     });
 
     expect(wrapper.text()).toContain('Con.');
     expect(wrapper.text()).not.toContain('Jour');
     expect(wrapper.text()).not.toContain('Nuit');
+  });
+
+  it('does not mark leave when day-month matches but leave year is different', () => {
+    const wrapper = shallowMount(PlanningTable, {
+      props: {
+        planning: {
+          Agent1: [['Mar. 01-04', 'Jour'], ['Mer. 02-04', 'Nuit']],
+        },
+        weekSchedule: ['Mar. 01-04', 'Mer. 02-04'],
+        vacationDurations: {
+          Jour: 8,
+          Nuit: 8,
+        },
+        vacationColors: {
+          Jour: '#75FA79',
+          Nuit: '#9175FA',
+        },
+        holidays: [],
+        unavailable: {
+          Agent1: [],
+        },
+        dayOff: {
+          Agent1: [['01-04-2025', '02-04-2025']],
+        },
+        training: {
+          Agent1: [],
+        },
+        planningStartDate: '2026-04-01',
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('Con.');
+    expect(wrapper.text()).toContain('Jour');
+    expect(wrapper.text()).toContain('Nuit');
+  });
+
+  it('marks leave on weekend days included in leave period', () => {
+    const wrapper = shallowMount(PlanningTable, {
+      props: {
+        planning: {
+          Agent1: [['Sam. 18-04', 'Jour'], ['Dim. 19-04', 'Nuit']],
+        },
+        weekSchedule: ['Sam. 18-04', 'Dim. 19-04'],
+        vacationDurations: {
+          Jour: 8,
+          Nuit: 8,
+        },
+        vacationColors: {
+          Jour: '#75FA79',
+          Nuit: '#9175FA',
+          'Con.': '#f2cb05',
+        },
+        holidays: [],
+        unavailable: {
+          Agent1: [],
+        },
+        dayOff: {
+          Agent1: [['18-04-2026', '19-04-2026']],
+        },
+        training: {
+          Agent1: [],
+        },
+        planningStartDate: '2026-04-18',
+      },
+    });
+
+    const text = wrapper.text();
+    expect(text.match(/Con\./g)?.length || 0).toBeGreaterThanOrEqual(2);
+    expect(text).not.toContain('Jour');
+    expect(text).not.toContain('Nuit');
   });
 });


### PR DESCRIPTION
## Summary
Fix cross-year leave matching and weekend leave rendering so planning behavior is consistent between backend solver and frontend table.

## Changes
- Added planning-start-date propagation (`planning_start_date`) from route to solver engine.
- Built deterministic full-date mapping for planning day labels in solver context.
- Updated leave blocking logic to compare full resolved dates instead of `dd-mm`-only matching.
- Updated backend leave helper to support reference-date-based year-safe resolution.
- Updated `PlanningTable` to resolve day labels from `planningStartDate` and match leave/unavailable/training using full config dates (`dd-mm-YYYY`).
- Ensured weekend days included in leave periods are rendered as `Con.`.
- Added/updated regression tests for cross-year leave collisions and weekend leave display.
- Updated changelog and solver modularization docs for the new date-handling rules.

## Tests
- Backend regression added: leave periods from 2025 do not affect a 2026 planning window.
- Backend helper tests updated for weekend inclusion and reference-year behavior.
- Frontend tests added:
  - no false leave match when `dd-mm` matches but year differs,
  - weekend leave rendering as `Con.` when weekend dates are inside the leave range.
- Existing related test suites remain aligned with the new date-resolution behavior.

## Why
Avoid year-collision bugs caused by `dd-mm` matching, keep solver and UI date logic consistent, and make leave rendering/calculation reliable around year boundaries and weekends.
