### PR TITLE
security(frontend): force node-forge to ^1.4.0 via overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13485,9 +13485,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,9 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-serializer-vue": "^3.1.0"
   },
+  "overrides": {
+    "node-forge": "^1.4.0"
+  },
   "eslintConfig": {
     "root": true,
     "env": {


### PR DESCRIPTION
## Objective
Apply a frontend security dependency remediation for `node-forge` without changing runtime feature behavior.

## Breaking Change Notice
No API/runtime breaking change is intended.
This PR enforces a patched transitive dependency version via `overrides`.

## Scope
- Frontend dependency hygiene/security only.
- Add `overrides.node-forge` to force `^1.4.0`.
- Refresh lockfile accordingly.
- No backend changes.

## Validation
- `npm audit`
- `npm audit --omit=dev`
- `npm test -- --runInBand`

## Results
- `node-forge` vulnerability (transitive) is remediated.
- Frontend tests remain green (`2/2` suites, `7/7` tests).
- Remaining audit findings are out of scope for this lot (next security batches).

## Risks and Mitigations
- Risk: dependency resolution side effects.
- Mitigation: isolated branch/PR, explicit override, lockfile update, and test/audit validation.
