### PR TITLE
release: 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-09
+
+### Security
+
+- frontend: applied non-breaking `npm audit fix` for devDependencies (Lot A), lockfile-only update.
+- reduced frontend audit findings from 27 to 19.
+- validation passed: `npm test -- --runInBand` and `npm run build`.
+- remaining findings are tied to legacy Vue CLI/Jest-jsdom upgrade paths and will be handled in a dedicated migration/security branch.
+
 ## [0.9.1] - 2026-05-09
 
 ### Security

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "axios": "^1.16.0",
         "core-js": "^3.49.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
## Objective
Publish version 0.9.2 with frontend devDependencies security maintenance Lot A.

## Scope
- Changelog release entry for `0.9.2` (2026-05-09)
- Frontend version bump
- Non-breaking lockfile security refresh (`npm audit fix`)

## Validation
- `npm audit` (findings reduced from 27 to 19)
- `npm test -- --runInBand` passed
- `npm run build` passed

## Notes
No intended functional/runtime breaking change.
Remaining vulnerabilities are tied to legacy Vue CLI/Jest-jsdom paths and will be handled in a dedicated migration/security branch.
