### PR TITLE
fix(backend): count night shifts in weekly hour cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Core sections in `config.json`:
 - `vacation_durations`: paid-hour durations for each configured shift plus `Conge`
 - `holidays`: recurring public holidays
 - `solver`: optional runtime and fairness tuning
+  - `max_weekly_hours`: strict weekly worked-hours cap per agent, default `36`
+  - `global_max_gap` / `period_max_gap`: paid-hour balance gaps between agents, expressed in tenths of hours
 
 ---
 

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -70,6 +70,7 @@
     "num_search_workers": 0,
     "global_max_gap": 240,
     "period_max_gap": 240,
+    "max_weekly_hours": 36,
     "optimize_period_balance": false,
     "period_balance_weight": 2,
     "min_free_weekends_per_horizon": 3

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -82,6 +82,10 @@
           "type": "integer",
           "minimum": 0
         },
+        "max_weekly_hours": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
         "optimize_period_balance": {
           "type": "boolean"
         },

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -21,12 +21,12 @@ def register(registry: ConstraintRegistry) -> None:
 
 def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
     """
-    Limits the number of weekly night shifts to 3 and the total weekly hours to 360.
+    Limits weekly night shifts and total worked hours.
 
     This constraint is applied per agent and per week in the week's schedule.
-    For each agent, it ensures that the agent is not assigned more than 3 night shifts
-    per week, and that the total number of hours worked by the agent per week is
-    less than or equal to 360.
+    For each agent, it allows at most 3 night shifts per week and caps worked
+    hours using solver.max_weekly_hours. The worked-hours cap counts all
+    configured vacations assigned by the solver and does not include paid leave.
 
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -40,12 +40,11 @@ def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
                     sum(ctx.planning[(agent_name, day, NIGHT_SHIFT)] for day in week) <= 3
                 )
 
-            total_heures = sum(
+            total_hours = sum(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in (DAY_SHIFT, CDP_SHIFT)
-                    if vacation in ctx.vacations
+                    for vacation in ctx.vacations
                 )
                 for day in week
             )
-            ctx.model.Add(total_heures <= 360)
+            ctx.model.Add(total_hours <= ctx.max_weekly_hours)

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -36,8 +36,9 @@ class SolverContext:
         conge_duration (int): Duration in minutes for leave/vacation shifts. Default: 0.
         
         max_time_seconds (int): Maximum solver runtime in seconds. Default: 600.
-        global_max_gap (int): Global maximum optimality gap in hours * 10. Default: 240.
-        period_max_gap (int): Period-specific maximum optimality gap in hours * 10. Default: 240.
+        global_max_gap (int): Global maximum balance gap in hours * 10. Default: 240.
+        period_max_gap (int): Period-specific balance gap in hours * 10. Default: 240.
+        max_weekly_hours (int): Maximum worked hours per agent per week in hours * 10. Default: 360.
         relative_gap_limit (float): Relative optimality gap limit as a fraction. Default: 0.10.
         num_search_workers (int): Number of parallel search workers for the solver. Default: 0.
         optimize_period_balance (bool): Flag to enable period balancing optimization. Default: False.
@@ -69,6 +70,7 @@ class SolverContext:
     max_time_seconds: int = 600
     global_max_gap: int = 240
     period_max_gap: int = 240
+    max_weekly_hours: int = 360
     relative_gap_limit: float = 0.10
     num_search_workers: int = 0
     optimize_period_balance: bool = False

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -34,8 +34,9 @@ def _load_solver_settings(ctx: SolverContext) -> None:
 
     This function sets the following solver context attributes from the config:
     - max_time_seconds: the maximum time in seconds the solver is allowed to run.
-    - global_max_gap: the maximum allowed gap in hours * 10 between two consecutive shifts.
-    - period_max_gap: the maximum allowed gap in hours * 10 between two consecutive shifts in the same period.
+    - global_max_gap: the maximum allowed balance gap in hours * 10.
+    - period_max_gap: the maximum allowed balance gap in hours * 10 for a period.
+    - max_weekly_hours: the maximum worked hours per agent per week, configured in hours.
     - relative_gap_limit: the maximum allowed relative gap between two consecutive shifts.
     - num_search_workers: the number of search workers to use.
     - optimize_period_balance: whether to optimize the period balance.
@@ -49,6 +50,7 @@ def _load_solver_settings(ctx: SolverContext) -> None:
     ctx.max_time_seconds = int(solver_config.get("max_time_seconds", 600))
     ctx.global_max_gap = int(solver_config.get("global_max_gap", 240))
     ctx.period_max_gap = int(solver_config.get("period_max_gap", 240))
+    ctx.max_weekly_hours = int(float(solver_config.get("max_weekly_hours", 36)) * 10)
     ctx.relative_gap_limit = float(solver_config.get("relative_gap_limit", 0.10))
     ctx.num_search_workers = int(solver_config.get("num_search_workers", 0))
     ctx.optimize_period_balance = bool(solver_config.get("optimize_period_balance", False))

--- a/backend/tests/test_config_schema.py
+++ b/backend/tests/test_config_schema.py
@@ -72,3 +72,30 @@ def test_schema_rejects_negative_staffing_requirement():
     errors = list(validator.iter_errors(example))
 
     assert errors != []
+
+
+def test_schema_accepts_max_weekly_hours():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["solver"]["max_weekly_hours"] = 42
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("max_weekly_hours", [0, -1])
+def test_schema_rejects_non_positive_max_weekly_hours(max_weekly_hours):
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["solver"]["max_weekly_hours"] = max_weekly_hours
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors != []
+    assert any(
+        "max_weekly_hours" in "/".join(str(part) for part in error.path)
+        for error in errors
+    )

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -1,7 +1,52 @@
 from copy import deepcopy
+from types import SimpleNamespace
 
 import pytest
+from ortools.sat.python import cp_model
 from app import generate_planning, get_active_config, load_default_config, set_active_config
+from solver.constraints.mixed import limit_weekly_nights_and_hours
+
+
+def _solve_forced_weekly_shifts(max_weekly_hours):
+    model = cp_model.CpModel()
+    agent_name = "Agent1"
+    vacations = ["Jour", "Nuit"]
+    week = ["Lun. 01-06", "Mar. 02-06", "Mer. 03-06", "Jeu. 04-06"]
+    planning = {
+        (agent_name, day, vacation): model.NewBoolVar(
+            f"planning_{agent_name}_{day}_{vacation}"
+        )
+        for day in week
+        for vacation in vacations
+    }
+
+    ctx = SimpleNamespace(
+        agents=[{"name": agent_name}],
+        vacations=vacations,
+        weeks_split=[week],
+        planning=planning,
+        shift_durations={"Jour": 120, "Nuit": 120},
+        max_weekly_hours=max_weekly_hours,
+        model=model,
+    )
+
+    limit_weekly_nights_and_hours(ctx)
+
+    forced_shifts = {
+        ("Lun. 01-06", "Jour"),
+        ("Mar. 02-06", "Jour"),
+        ("Mer. 03-06", "Nuit"),
+        ("Jeu. 04-06", "Nuit"),
+    }
+    for day in week:
+        for vacation in vacations:
+            model.Add(
+                planning[(agent_name, day, vacation)]
+                == int((day, vacation) in forced_shifts)
+            )
+
+    solver = cp_model.CpSolver()
+    return solver.Solve(model)
 
 
 @pytest.fixture(autouse=True)
@@ -604,6 +649,29 @@ def test_generate_planning_ignores_leave_periods_from_other_years():
 
     assert isinstance(result, dict)
     assert "info" not in result
+
+
+def test_weekly_hours_limit_counts_night_shifts_with_default_cap():
+    """
+    Regression test: weekly hour cap must count night shifts, not only day/CDP.
+
+    Two day shifts and two night shifts at 12h each exceed the default 36h cap,
+    even though day-only hours and night-only count are independently valid.
+    """
+
+    status = _solve_forced_weekly_shifts(max_weekly_hours=360)
+
+    assert status == cp_model.INFEASIBLE
+
+
+def test_weekly_hours_limit_uses_configured_cap():
+    """
+    The same 48h worked week becomes feasible when solver.max_weekly_hours is 48.
+    """
+
+    status = _solve_forced_weekly_shifts(max_weekly_hours=480)
+
+    assert status in [cp_model.OPTIMAL, cp_model.FEASIBLE]
     
 ######
 # Test failed, possible bug in the generate_planning function (constraint not respected or too soft)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -84,8 +84,14 @@ Supported keys:
 - `max_time_seconds` (integer, default `600`)
 - `relative_gap_limit` (number in `(0, 1]`, default `0.1`)
 - `num_search_workers` (integer, default `0`)
+- `max_weekly_hours` (number, default `36`)
+  - Strict maximum worked hours per agent and per week.
+  - Counts all generated shift types in `vacations`.
+  - Does not include paid leave hours.
 - `global_max_gap` (integer, default `240`)
+  - Maximum paid-hour balance gap between agents over the generated period, in tenths of hours.
 - `period_max_gap` (integer, default `240`)
+  - Maximum paid-hour balance gap between agents inside each period, in tenths of hours.
 - `optimize_period_balance` (boolean, default `false`)
 - `period_balance_weight` (integer, default `2`)
 


### PR DESCRIPTION
## Objective
Fix weekly worked-hours calculation so night shifts are included in the per-agent weekly cap, then make that cap configurable through `solver.max_weekly_hours`.

## Breaking Change Notice
No API breaking change.

The default weekly cap remains `36h`, preserving existing behavior. Schedules that previously exceeded the real weekly worked-hours cap because night shifts were not counted may now correctly become infeasible.

## Scope
- Count all configured worked vacations in the weekly hours cap, including `Nuit`.
- Add configurable `solver.max_weekly_hours`, expressed in hours, with default `36`.
- Wire `max_weekly_hours` through solver config loading and `SolverContext`.
- Update config schema and example config.
- Clarify documentation for:
  - strict weekly worked-hours cap
  - paid-hour balance gaps (`global_max_gap`, `period_max_gap`)
- Add regression tests for:
  - default `36h` cap rejecting `2 Jour + 2 Nuit`
  - configured `48h` cap accepting the same worked week
  - schema validation for `max_weekly_hours`

## Validation
- `backend/.venv/Scripts/python.exe -m pytest backend/tests/test_constraints.py -q`
- `backend/.venv/Scripts/python.exe -m pytest backend/tests/test_dynamic_solver_config.py backend/tests/test_config_schema.py -q -k "not test_config_json_matches_schema"`
- `backend/.venv/Scripts/python.exe -m pytest backend/tests -q`

## Results
- Constraint tests pass: `10/10`.
- Dynamic solver config and schema tests pass when excluding local `backend/config.json`: `11 passed, 1 deselected`.
- Full backend suite: `86 passed, 1 failed`.

The remaining failure is local-config related and out of scope: `backend/config.json` contains `restriction_types_durations`, a key used by another branch but not yet declared in this branch schema.

## Risks and Mitigations
- Risk: some schedules that were incorrectly feasible may now be rejected because night hours are counted.
- Mitigation: the cap is configurable via `solver.max_weekly_hours`; default remains `36h`.
- Risk: future half-vacation behavior may require a higher cap such as `42h`.
- Mitigation: this PR prepares the configuration hook without introducing half-vacations yet.