### PR TITLE
Enhance weekly hours constraints and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-01
+
+### Fixed
+
+- Fixed weekly worked-hours caps so they count all configured worked vacations, including `Nuit`.
+- Added `solver.max_weekly_hours` as a configurable weekly cap with default `36h`.
+
 ## [0.9.2] - 2026-05-09
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Core sections in `config.json`:
 - `vacation_durations`: paid-hour durations for each configured shift plus `Conge`
 - `holidays`: recurring public holidays
 - `solver`: optional runtime and fairness tuning
+  - `max_weekly_hours`: strict weekly worked-hours cap per agent, default `36`
+  - `global_max_gap` / `period_max_gap`: paid-hour balance gaps between agents, expressed in tenths of hours
 
 ---
 

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -70,6 +70,7 @@
     "num_search_workers": 0,
     "global_max_gap": 240,
     "period_max_gap": 240,
+    "max_weekly_hours": 36,
     "optimize_period_balance": false,
     "period_balance_weight": 2,
     "min_free_weekends_per_horizon": 3

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -82,6 +82,10 @@
           "type": "integer",
           "minimum": 0
         },
+        "max_weekly_hours": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
         "optimize_period_balance": {
           "type": "boolean"
         },

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -21,12 +21,12 @@ def register(registry: ConstraintRegistry) -> None:
 
 def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
     """
-    Limits the number of weekly night shifts to 3 and the total weekly hours to 360.
+    Limits weekly night shifts and total worked hours.
 
     This constraint is applied per agent and per week in the week's schedule.
-    For each agent, it ensures that the agent is not assigned more than 3 night shifts
-    per week, and that the total number of hours worked by the agent per week is
-    less than or equal to 360.
+    For each agent, it allows at most 3 night shifts per week and caps worked
+    hours using solver.max_weekly_hours. The worked-hours cap counts all
+    configured vacations assigned by the solver and does not include paid leave.
 
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -40,12 +40,11 @@ def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
                     sum(ctx.planning[(agent_name, day, NIGHT_SHIFT)] for day in week) <= 3
                 )
 
-            total_heures = sum(
+            total_hours = sum(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in (DAY_SHIFT, CDP_SHIFT)
-                    if vacation in ctx.vacations
+                    for vacation in ctx.vacations
                 )
                 for day in week
             )
-            ctx.model.Add(total_heures <= 360)
+            ctx.model.Add(total_hours <= ctx.max_weekly_hours)

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -36,8 +36,9 @@ class SolverContext:
         conge_duration (int): Duration in minutes for leave/vacation shifts. Default: 0.
         
         max_time_seconds (int): Maximum solver runtime in seconds. Default: 600.
-        global_max_gap (int): Global maximum optimality gap in hours * 10. Default: 240.
-        period_max_gap (int): Period-specific maximum optimality gap in hours * 10. Default: 240.
+        global_max_gap (int): Global maximum balance gap in hours * 10. Default: 240.
+        period_max_gap (int): Period-specific balance gap in hours * 10. Default: 240.
+        max_weekly_hours (int): Maximum worked hours per agent per week in hours * 10. Default: 360.
         relative_gap_limit (float): Relative optimality gap limit as a fraction. Default: 0.10.
         num_search_workers (int): Number of parallel search workers for the solver. Default: 0.
         optimize_period_balance (bool): Flag to enable period balancing optimization. Default: False.
@@ -69,6 +70,7 @@ class SolverContext:
     max_time_seconds: int = 600
     global_max_gap: int = 240
     period_max_gap: int = 240
+    max_weekly_hours: int = 360
     relative_gap_limit: float = 0.10
     num_search_workers: int = 0
     optimize_period_balance: bool = False

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -34,8 +34,9 @@ def _load_solver_settings(ctx: SolverContext) -> None:
 
     This function sets the following solver context attributes from the config:
     - max_time_seconds: the maximum time in seconds the solver is allowed to run.
-    - global_max_gap: the maximum allowed gap in hours * 10 between two consecutive shifts.
-    - period_max_gap: the maximum allowed gap in hours * 10 between two consecutive shifts in the same period.
+    - global_max_gap: the maximum allowed balance gap in hours * 10.
+    - period_max_gap: the maximum allowed balance gap in hours * 10 for a period.
+    - max_weekly_hours: the maximum worked hours per agent per week, configured in hours.
     - relative_gap_limit: the maximum allowed relative gap between two consecutive shifts.
     - num_search_workers: the number of search workers to use.
     - optimize_period_balance: whether to optimize the period balance.
@@ -49,6 +50,7 @@ def _load_solver_settings(ctx: SolverContext) -> None:
     ctx.max_time_seconds = int(solver_config.get("max_time_seconds", 600))
     ctx.global_max_gap = int(solver_config.get("global_max_gap", 240))
     ctx.period_max_gap = int(solver_config.get("period_max_gap", 240))
+    ctx.max_weekly_hours = int(float(solver_config.get("max_weekly_hours", 36)) * 10)
     ctx.relative_gap_limit = float(solver_config.get("relative_gap_limit", 0.10))
     ctx.num_search_workers = int(solver_config.get("num_search_workers", 0))
     ctx.optimize_period_balance = bool(solver_config.get("optimize_period_balance", False))

--- a/backend/tests/test_config_schema.py
+++ b/backend/tests/test_config_schema.py
@@ -72,3 +72,30 @@ def test_schema_rejects_negative_staffing_requirement():
     errors = list(validator.iter_errors(example))
 
     assert errors != []
+
+
+def test_schema_accepts_max_weekly_hours():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["solver"]["max_weekly_hours"] = 42
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("max_weekly_hours", [0, -1])
+def test_schema_rejects_non_positive_max_weekly_hours(max_weekly_hours):
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["solver"]["max_weekly_hours"] = max_weekly_hours
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors != []
+    assert any(
+        "max_weekly_hours" in "/".join(str(part) for part in error.path)
+        for error in errors
+    )

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -1,7 +1,52 @@
 from copy import deepcopy
+from types import SimpleNamespace
 
 import pytest
+from ortools.sat.python import cp_model
 from app import generate_planning, get_active_config, load_default_config, set_active_config
+from solver.constraints.mixed import limit_weekly_nights_and_hours
+
+
+def _solve_forced_weekly_shifts(max_weekly_hours):
+    model = cp_model.CpModel()
+    agent_name = "Agent1"
+    vacations = ["Jour", "Nuit"]
+    week = ["Lun. 01-06", "Mar. 02-06", "Mer. 03-06", "Jeu. 04-06"]
+    planning = {
+        (agent_name, day, vacation): model.NewBoolVar(
+            f"planning_{agent_name}_{day}_{vacation}"
+        )
+        for day in week
+        for vacation in vacations
+    }
+
+    ctx = SimpleNamespace(
+        agents=[{"name": agent_name}],
+        vacations=vacations,
+        weeks_split=[week],
+        planning=planning,
+        shift_durations={"Jour": 120, "Nuit": 120},
+        max_weekly_hours=max_weekly_hours,
+        model=model,
+    )
+
+    limit_weekly_nights_and_hours(ctx)
+
+    forced_shifts = {
+        ("Lun. 01-06", "Jour"),
+        ("Mar. 02-06", "Jour"),
+        ("Mer. 03-06", "Nuit"),
+        ("Jeu. 04-06", "Nuit"),
+    }
+    for day in week:
+        for vacation in vacations:
+            model.Add(
+                planning[(agent_name, day, vacation)]
+                == int((day, vacation) in forced_shifts)
+            )
+
+    solver = cp_model.CpSolver()
+    return solver.Solve(model)
 
 
 @pytest.fixture(autouse=True)
@@ -604,6 +649,29 @@ def test_generate_planning_ignores_leave_periods_from_other_years():
 
     assert isinstance(result, dict)
     assert "info" not in result
+
+
+def test_weekly_hours_limit_counts_night_shifts_with_default_cap():
+    """
+    Regression test: weekly hour cap must count night shifts, not only day/CDP.
+
+    Two day shifts and two night shifts at 12h each exceed the default 36h cap,
+    even though day-only hours and night-only count are independently valid.
+    """
+
+    status = _solve_forced_weekly_shifts(max_weekly_hours=360)
+
+    assert status == cp_model.INFEASIBLE
+
+
+def test_weekly_hours_limit_uses_configured_cap():
+    """
+    The same 48h worked week becomes feasible when solver.max_weekly_hours is 48.
+    """
+
+    status = _solve_forced_weekly_shifts(max_weekly_hours=480)
+
+    assert status in [cp_model.OPTIMAL, cp_model.FEASIBLE]
     
 ######
 # Test failed, possible bug in the generate_planning function (constraint not respected or too soft)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -84,8 +84,14 @@ Supported keys:
 - `max_time_seconds` (integer, default `600`)
 - `relative_gap_limit` (number in `(0, 1]`, default `0.1`)
 - `num_search_workers` (integer, default `0`)
+- `max_weekly_hours` (number, default `36`)
+  - Strict maximum worked hours per agent and per week.
+  - Counts all generated shift types in `vacations`.
+  - Does not include paid leave hours.
 - `global_max_gap` (integer, default `240`)
+  - Maximum paid-hour balance gap between agents over the generated period, in tenths of hours.
 - `period_max_gap` (integer, default `240`)
+  - Maximum paid-hour balance gap between agents inside each period, in tenths of hours.
 - `optimize_period_balance` (boolean, default `false`)
 - `period_balance_weight` (integer, default `2`)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "axios": "^1.16.0",
         "core-js": "^3.49.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
This pull request introduces a new configurable weekly worked-hours cap to the solver, improves documentation, and adds robust validation and testing for this new feature. The default weekly cap is now set to 36 hours, and the constraint now properly counts all configured worked vacations, including night shifts. The change is reflected across the backend, configuration files, documentation, and tests.

**Solver constraint and configuration improvements:**

* Added `solver.max_weekly_hours` as a configurable weekly worked-hours cap per agent (default 36h), enforced in the solver and counted for all configured worked vacations, including night shifts. The constraint now uses this value instead of a hardcoded limit and is documented in the code and config files. [[1]](diffhunk://#diff-ecc218c9dc0c489bc568422d812f07f7fb9dc9d95e6b625c3f68e501adabd618L24-R29) [[2]](diffhunk://#diff-ecc218c9dc0c489bc568422d812f07f7fb9dc9d95e6b625c3f68e501adabd618L43-R50) [[3]](diffhunk://#diff-408309f48ee821b7156895fa46bfe7ddb9a2274eb69b3d328762da40c8d9bd1fL39-R41) [[4]](diffhunk://#diff-408309f48ee821b7156895fa46bfe7ddb9a2274eb69b3d328762da40c8d9bd1fR73) [[5]](diffhunk://#diff-bda64ba7b743f0722e2477d9cf0677ad1e4122af6bf3058cfc5da3e4809ac9fcL37-R39) [[6]](diffhunk://#diff-bda64ba7b743f0722e2477d9cf0677ad1e4122af6bf3058cfc5da3e4809ac9fcR53) [[7]](diffhunk://#diff-42b91be20c04ab08e478d6b5fd5810a080690b5e20dae37354ec6c2144706952R73) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R160) [[9]](diffhunk://#diff-a67c85db862506adf921418c25fa942232f80fb73d48aa406d07c909cbfd83f4R87-R94)

**Documentation and changelog updates:**

* Updated `CHANGELOG.md` and documentation files to describe the new weekly hours cap and clarify related configuration options. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R160) [[3]](diffhunk://#diff-a67c85db862506adf921418c25fa942232f80fb73d48aa406d07c909cbfd83f4R87-R94)

**Validation and schema enhancements:**

* Extended the configuration schema to support the new `max_weekly_hours` setting, requiring it to be a positive number, and updated example configs accordingly. [[1]](diffhunk://#diff-41288d4a5a6d333327e61e79addf5ffa8e9ca3bc17de75949a3fdb94f7623cbfR85-R88) [[2]](diffhunk://#diff-42b91be20c04ab08e478d6b5fd5810a080690b5e20dae37354ec6c2144706952R73)

**Testing improvements:**

* Added and improved tests to verify that the weekly hours cap is enforced, including regression tests for night shift counting and parameterized tests for schema validation. [[1]](diffhunk://#diff-550359ecfa093eba65293e127058aefc677cc2172a8720b906c7e51154b5dbb1R75-R101) [[2]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5R2-R49) [[3]](diffhunk://#diff-156c33afcf5dc7d363160f551f14701303a990d338548dc16b9c1001579d3cc5R653-R675)

**Version bump:**

* Bumped the version to `0.9.3` in both backend and frontend to reflect these changes. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L3-R3)