### PR TITLE
Half vacation scheduling support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from jsonschema import Draft202012Validator
+from solver.catalog import build_vacation_catalog, is_night_assignment, requires_next_day_rest
 from solver.engine import generate_planning as generate_planning_engine
 
 app = Flask(__name__)
@@ -59,6 +60,23 @@ def validate_runtime_config(candidate_config):
                         "message": (
                             f"Missing duration for configured vacation '{vacation}'."
                         ),
+                    }
+                )
+
+    if not errors:
+        try:
+            build_vacation_catalog(candidate_config)
+        except ValueError as exc:
+            errors.append({"path": "half_vacations", "message": str(exc)})
+
+    half_vacations = candidate_config.get("half_vacations", {})
+    if isinstance(vacations, list) and isinstance(half_vacations, dict):
+        for parent in half_vacations:
+            if parent not in vacations:
+                errors.append(
+                    {
+                        "path": f"half_vacations/{parent}",
+                        "message": f"Unknown parent vacation '{parent}'.",
                     }
                 )
 
@@ -148,7 +166,11 @@ def _build_planning_payload(payload, runtime_config):
     # Retrieving data from the JSON file
     agents = runtime_config["agents"]
     vacations = runtime_config["vacations"]
-    vacation_durations = runtime_config["vacation_durations"]
+    catalog = build_vacation_catalog(runtime_config)
+    assignable_vacations = catalog["assignable_vacations"]
+    vacation_durations = dict(runtime_config["vacation_durations"])
+    for assignment, metadata in catalog["assignment_metadata"].items():
+        vacation_durations[assignment] = metadata.duration / 10
     holidays = runtime_config["holidays"]
     unavailable = {}
     dayOff = {}
@@ -188,7 +210,7 @@ def _build_planning_payload(payload, runtime_config):
 
     # Validate initial shifts
     valid_agents = [agent["name"] for agent in agents]
-    valid_vacations = vacations
+    valid_vacations = assignable_vacations
     for agent_name, shifts in initial_shifts.items():
         if not isinstance(shifts, list):
             return {"error": f"initial_shifts for {agent_name} must be a list"}, 400
@@ -267,6 +289,8 @@ def _build_planning_payload(payload, runtime_config):
     return {
         "planning": full_planning,
         "vacation_durations": vacation_durations,
+        "vacation_colors": runtime_config.get("vacation_colors", {}),
+        "assignable_vacations": assignable_vacations,
         "week_schedule": original_week_schedule,
         "holidays": holidays,
         "unavailable": unavailable,
@@ -334,7 +358,7 @@ def _parse_manual_entries(manual_entries, runtime_config, start_date, end_date):
         return None, None, None, (jsonify({"error": "manual_entries must be a list"}), 400)
 
     valid_agents = {agent["name"] for agent in runtime_config["agents"]}
-    valid_vacations = set(runtime_config["vacations"])
+    valid_vacations = set(build_vacation_catalog(runtime_config)["assignable_vacations"])
     valid_restriction_types = set(
         (runtime_config.get("restriction_types_durations") or {}).keys()
     )
@@ -544,7 +568,7 @@ def _build_manual_shift_indexes(manual_entries):
     return manual_shifts_by_agent_day, manual_counts_by_day_shift, dates_to_check
 
 
-def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day):
+def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config):
     agent_name = agent["name"]
     locked_shifts = manual_shifts_by_agent_day.get((agent_name, iso_date), [])
     if locked_shifts:
@@ -552,16 +576,19 @@ def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day
 
     if _agent_has_status_on_day(agent, iso_date):
         return False
-    if vacation in (agent.get("restriction") or []):
+    restricted = set(agent.get("restriction") or [])
+    if vacation in restricted:
+        return False
+    catalog = build_vacation_catalog(runtime_config)
+    metadata = catalog["assignment_metadata"].get(vacation)
+    if metadata and metadata.parent in restricted:
         return False
     return True
-
 
 def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_config):
     reasons = []
     by_agent = {agent["name"]: agent for agent in runtime_config.get("agents", [])}
     details_by_code = {
-        "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED": [],
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": [],
         "MANUAL_SHIFT_AFTER_NIGHT": [],
         "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": [],
@@ -569,22 +596,17 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
         "MANUAL_FULL_WEEKEND_COMPOSITION_CONFLICT": [],
     }
     counts_by_code = {code: 0 for code in details_by_code}
+    catalog = build_vacation_catalog(runtime_config)
 
     weekly_counts = {}
     for (agent_name, iso_date), shifts in manual_shifts_by_agent_day.items():
         if agent_name not in by_agent or not is_valid_date(iso_date):
             continue
         week_key = (agent_name, datetime.strptime(iso_date, "%Y-%m-%d").isocalendar()[:2])
-        weekly_counts.setdefault(week_key, {"Jour": 0, "CDP": 0})
-        weekly_counts[week_key]["Jour"] += shifts.count("Jour")
+        weekly_counts.setdefault(week_key, {"CDP": 0})
         weekly_counts[week_key]["CDP"] += shifts.count("CDP")
 
     for (agent_name, week), counts in weekly_counts.items():
-        if counts["Jour"] > 3:
-            counts_by_code["MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"] += 1
-            details_by_code["MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"].append(
-                f"{agent_name} / semaine {week[1]}: {counts['Jour']} vacations Jour manuelles pour 3 maximum"
-            )
         if counts["CDP"] > 2:
             counts_by_code["MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED"] += 1
             details_by_code["MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED"].append(
@@ -600,17 +622,21 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
         next_iso = (day_dt + timedelta(days=1)).strftime("%Y-%m-%d")
         next_day_str = (day_dt + timedelta(days=1)).strftime("%d-%m-%Y")
 
-        if "Nuit" in shifts:
+        rest_triggering_shifts = [
+            shift for shift in shifts if requires_next_day_rest(catalog, shift)
+        ]
+        if rest_triggering_shifts:
             next_manual_shifts = manual_shifts_by_agent_day.get((agent_name, next_iso), [])
             if next_manual_shifts:
                 counts_by_code["MANUAL_SHIFT_AFTER_NIGHT"] += 1
                 details_by_code["MANUAL_SHIFT_AFTER_NIGHT"].append(
-                    f"{agent_name} / {iso_date}: Nuit suivie de {', '.join(next_manual_shifts)} le {next_iso}"
+                    f"{agent_name} / {iso_date}: {', '.join(rest_triggering_shifts)} "
+                    f"suivie de {', '.join(next_manual_shifts)} le {next_iso}"
                 )
             if next_day_str in (agent.get("unavailable") or []) or next_day_str in (agent.get("training") or []):
                 counts_by_code["MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING"] += 1
                 details_by_code["MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING"].append(
-                    f"{agent_name} / {iso_date}: Nuit avant indisponibilité ou formation le {next_iso}"
+                    f"{agent_name} / {iso_date}: affectation de nuit avant indisponibilité ou formation le {next_iso}"
                 )
 
         if day_dt.weekday() == 5 and _agent_has_status_on_day(agent, next_iso):
@@ -628,7 +654,11 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
             previous_shifts = manual_shifts_by_agent_day.get((agent_name, previous_iso), [])
             next_shifts = manual_shifts_by_agent_day.get((agent_name, next_iso), [])
             forbidden_previous = [shift for shift in previous_shifts if shift != "CDP"]
-            forbidden_next = [shift for shift in next_shifts if shift not in {"CDP", "Nuit"}]
+            forbidden_next = [
+                shift
+                for shift in next_shifts
+                if shift != "CDP" and not is_night_assignment(catalog, shift)
+            ]
             if forbidden_previous or forbidden_next:
                 counts_by_code["MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED"] += 1
                 details_by_code["MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED"].append(
@@ -636,7 +666,6 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
                 )
 
     reason_messages = {
-        "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED": "La limite de 3 vacations Jour par semaine est dépassée par des saisies manuelles.",
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": "La limite de 2 vacations CDP par semaine est dépassée par des saisies manuelles.",
         "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle est posée le lendemain d'une Nuit manuelle.",
         "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": "Une Nuit manuelle est posée avant une indisponibilité ou une formation.",
@@ -662,9 +691,9 @@ def _diagnose_staffing_capacity_conflicts(
 ):
     reasons = []
     agents = runtime_config.get("agents", [])
-    vacations = runtime_config.get("vacations", [])
     staffing_requirements = runtime_config.get("staffing_requirements", {})
     holidays = set(runtime_config.get("holidays", []))
+    catalog = build_vacation_catalog(runtime_config)
 
     understaffed_shift_days = 0
     overstaffed_manual_shift_days = 0
@@ -675,37 +704,55 @@ def _diagnose_staffing_capacity_conflicts(
         day_dt = datetime.strptime(iso_date, "%Y-%m-%d")
         day_token = day_dt.strftime("%d-%m")
         is_weekend = day_dt.weekday() >= 5
-        for vacation in vacations:
+        for vacation in catalog["coverage_vacations"]:
             required_agents = staffing_requirements.get(vacation, 1)
             if vacation == "CDP" and (is_weekend or day_token in holidays):
                 required_agents = 0
 
-            manual_count = manual_counts_by_day_shift.get((iso_date, vacation), 0)
-            if manual_count > required_agents:
-                overstaffed_manual_shift_days += 1
-                overstaffed_details.append(
-                    f"{iso_date} / {vacation}: {manual_count} manuel(s) pour {required_agents} requis"
+            for segment in catalog["coverage_segments"].get(vacation, [vacation]):
+                covering_assignments = catalog["segment_covering_assignments"].get(
+                    (vacation, segment), [vacation]
                 )
-                continue
+                manual_count = sum(
+                    manual_counts_by_day_shift.get((iso_date, assignment), 0)
+                    for assignment in covering_assignments
+                )
+                if manual_count > required_agents:
+                    overstaffed_manual_shift_days += 1
+                    overstaffed_details.append(
+                        f"{iso_date} / {vacation} / {segment}: "
+                        f"{manual_count} manuel(s) pour {required_agents} requis"
+                    )
+                    continue
 
-            eligible_count = sum(
-                1
-                for agent in agents
-                if _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day)
-            )
-            if eligible_count < required_agents:
-                understaffed_shift_days += 1
-                understaffed_details.append(
-                    f"{iso_date} / {vacation}: {eligible_count} agent(s) possible(s) pour {required_agents} requis"
+                eligible_count = sum(
+                    1
+                    for agent in agents
+                    if any(
+                        _agent_can_cover_shift(
+                            agent,
+                            iso_date,
+                            assignment,
+                            manual_shifts_by_agent_day,
+                            runtime_config,
+                        )
+                        for assignment in covering_assignments
+                    )
                 )
+                if eligible_count < required_agents:
+                    understaffed_shift_days += 1
+                    understaffed_details.append(
+                        f"{iso_date} / {vacation} / {segment}: "
+                        f"{eligible_count} agent(s) possible(s) pour {required_agents} requis"
+                    )
 
     if overstaffed_manual_shift_days:
         reasons.append(
             {
                 "code": "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT",
                 "message": (
-                    "Trop de vacations manuelles sont posées sur au moins un couple "
-                    "date/vacation par rapport au besoin configuré."
+                    "Trop d'affectations manuelles sont posées sur au moins un "
+                    "segment par rapport au besoin configuré."
                 ),
                 "count": overstaffed_manual_shift_days,
                 "details": overstaffed_details[:5],
@@ -716,8 +763,8 @@ def _diagnose_staffing_capacity_conflicts(
             {
                 "code": "STAFFING_REQUIREMENT_UNMET",
                 "message": (
-                    "Le besoin de couverture ne peut pas être atteint pour au moins une "
-                    "date/vacation avec les agents encore disponibles."
+                    "Le besoin de couverture ne peut pas être atteint pour au moins "
+                    "un segment avec les agents encore disponibles."
                 ),
                 "count": understaffed_shift_days,
                 "details": understaffed_details[:5],
@@ -777,11 +824,6 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
         "constraint": "block_leave_and_compute_paid_hours",
         "label": "congés",
         "detail": "Relâcher les congés rendrait le planning faisable, ce qui indique un manque de capacité disponible.",
-    },
-    {
-        "constraint": "limit_day_shifts_per_week",
-        "label": "limite de 3 vacations Jour par semaine",
-        "detail": "La limite hebdomadaire des vacations Jour semble trop contraignante pour couvrir la période.",
     },
     {
         "constraint": "block_night_before_unavailable",
@@ -962,8 +1004,14 @@ def compute_previous_week_schedule():
     start_date = payload["start_date"]
     previous_week_schedule = get_previous_week_schedule(start_date)
 
-    agents = get_active_config()["agents"]
-    return jsonify({"previous_week_schedule": previous_week_schedule, "agents": agents})
+    runtime_config = get_active_config()
+    agents = runtime_config["agents"]
+    assignable_vacations = build_vacation_catalog(runtime_config)["assignable_vacations"]
+    return jsonify({
+        "previous_week_schedule": previous_week_schedule,
+        "agents": agents,
+        "assignable_vacations": assignable_vacations,
+    })
 
 
 @app.route("/optimize-existing-planning", methods=["POST"])

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -3,33 +3,57 @@
     {
       "name": "Agent1",
       "preferences": {
-        "preferred": ["Jour", "CDP"],
-        "avoid": ["Nuit"]
+        "preferred": [
+          "Jour",
+          "CDP"
+        ],
+        "avoid": [
+          "Nuit"
+        ]
       },
       "restriction": [],
-      "unavailable": ["15-01-2026"],
-      "training": ["20-01-2026"],
+      "unavailable": [
+        "15-01-2026"
+      ],
+      "training": [
+        "20-01-2026"
+      ],
       "exclusion": [],
       "vacations": [
-        { "start": "02-03-2026", "end": "08-03-2026" }
+        {
+          "start": "02-03-2026",
+          "end": "08-03-2026"
+        }
       ]
     },
     {
       "name": "Agent2",
       "preferences": {
-        "preferred": ["Nuit"],
-        "avoid": ["Jour", "CDP"]
+        "preferred": [
+          "Nuit"
+        ],
+        "avoid": [
+          "Jour",
+          "CDP"
+        ]
       },
-      "restriction": ["Jour"],
+      "restriction": [
+        "Jour"
+      ],
       "unavailable": [],
       "training": [],
-      "exclusion": ["01-01-2026"],
+      "exclusion": [
+        "01-01-2026"
+      ],
       "vacations": []
     },
     {
       "name": "Agent3",
       "preferences": {
-        "preferred": ["Jour", "CDP"],
+        "preferred": [
+          "Jour",
+          "CDP"
+        ],
         "avoid": []
       },
       "restriction": [],
@@ -37,11 +61,18 @@
       "training": [],
       "exclusion": [],
       "vacations": [
-        { "start": "10-08-2026", "end": "23-08-2026" }
+        {
+          "start": "10-08-2026",
+          "end": "23-08-2026"
+        }
       ]
     }
   ],
-  "vacations": ["Jour", "Nuit", "CDP"],
+  "vacations": [
+    "Jour",
+    "Nuit",
+    "CDP"
+  ],
   "staffing_requirements": {
     "Jour": 1,
     "Nuit": 1,
@@ -78,5 +109,52 @@
     "optimize_period_balance": false,
     "period_balance_weight": 2,
     "min_free_weekends_per_horizon": 3
+  },
+  "half_vacations": {
+    "Jour": {
+      "enabled": true,
+      "penalty": 500,
+      "segments": [
+        {
+          "name": "Jour matin",
+          "label": "J matin",
+          "duration": 6
+        },
+        {
+          "name": "Jour après-midi",
+          "label": "J aprem",
+          "duration": 6
+        }
+      ]
+    },
+    "Nuit": {
+      "enabled": true,
+      "penalty": 700,
+      "segments": [
+        {
+          "name": "Nuit début",
+          "label": "N début",
+          "duration": 6,
+          "is_night": true,
+          "requires_next_day_rest": true
+        },
+        {
+          "name": "Nuit fin",
+          "label": "N fin",
+          "duration": 6,
+          "is_night": true,
+          "requires_next_day_rest": true
+        }
+      ]
+    }
+  },
+  "vacation_colors": {
+    "Jour": "#75FA79",
+    "Jour matin": "#B9F6CA",
+    "Jour après-midi": "#00C853",
+    "Nuit": "#9175FA",
+    "Nuit début": "#B39DDB",
+    "Nuit fin": "#673AB7",
+    "CDP": "#FFD966"
   }
 }

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -105,6 +105,25 @@
           "minimum": 0
         }
       }
+    },
+    "half_vacations": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/half_vacation"
+      }
+    },
+    "vacation_colors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^#[0-9A-Fa-f]{6}$"
+      }
+    },
+    "vacation_metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/vacation_metadata"
+      }
     }
   },
   "$defs": {
@@ -203,6 +222,74 @@
               }
             }
           }
+        }
+      }
+    },
+    "vacation_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "is_night": {
+          "type": "boolean"
+        },
+        "requires_next_day_rest": {
+          "type": "boolean"
+        }
+      }
+    },
+    "half_vacation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "penalty",
+        "segments"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "penalty": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "segments": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/half_vacation_segment"
+          }
+        }
+      }
+    },
+    "half_vacation_segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "duration"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/shift"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "duration": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "is_night": {
+          "type": "boolean"
+        },
+        "requires_next_day_rest": {
+          "type": "boolean"
         }
       }
     }

--- a/backend/solver/catalog.py
+++ b/backend/solver/catalog.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_NIGHT_SHIFT_NAMES = {"Nuit"}
+
+
+@dataclass(frozen=True)
+class AssignmentMetadata:
+    name: str
+    parent: str
+    duration: int
+    is_half: bool = False
+    segment: str | None = None
+    label: str | None = None
+    penalty: int = 0
+    is_night: bool = False
+    requires_next_day_rest: bool = False
+
+
+def _duration_to_tenths(value: Any, field_name: str) -> int:
+    try:
+        duration = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a positive number") from exc
+    if duration <= 0:
+        raise ValueError(f"{field_name} must be a positive number")
+    return int(round(duration * 10))
+
+
+def _is_enabled_half_config(half_config: dict[str, Any]) -> bool:
+    return bool(half_config.get("enabled", True))
+
+
+def build_vacation_catalog(config: dict[str, Any]) -> dict[str, Any]:
+    """Build a normalized assignment catalog from user-facing vacation config."""
+    coverage_vacations = list(config.get("vacations") or [])
+    configured_durations = config.get("vacation_durations") or {}
+    half_vacations = config.get("half_vacations") or {}
+    vacation_metadata = config.get("vacation_metadata") or {}
+
+    assignment_metadata: dict[str, AssignmentMetadata] = {}
+    assignable_vacations: list[str] = []
+    coverage_segments: dict[str, list[str]] = {}
+    segment_covering_assignments: dict[tuple[str, str], list[str]] = {}
+    half_vacation_names: set[str] = set()
+
+    for parent in coverage_vacations:
+        if parent not in configured_durations:
+            raise ValueError(
+                "Missing vacation_durations entries for configured vacations: "
+                f"{parent}"
+            )
+        parent_duration = _duration_to_tenths(
+            configured_durations[parent], f"vacation_durations[{parent}]"
+        )
+        parent_metadata = vacation_metadata.get(parent) or {}
+        parent_is_night = bool(parent_metadata.get("is_night", parent in DEFAULT_NIGHT_SHIFT_NAMES))
+        parent_requires_rest = bool(
+            parent_metadata.get("requires_next_day_rest", parent_is_night)
+        )
+        assignment_metadata[parent] = AssignmentMetadata(
+            name=parent,
+            parent=parent,
+            duration=parent_duration,
+            is_half=False,
+            label=parent_metadata.get("label", parent),
+            is_night=parent_is_night,
+            requires_next_day_rest=parent_requires_rest,
+        )
+        assignable_vacations.append(parent)
+
+        parent_half_config = half_vacations.get(parent)
+        if isinstance(parent_half_config, dict) and _is_enabled_half_config(parent_half_config):
+            segments = parent_half_config.get("segments") or []
+            if not segments:
+                coverage_segments[parent] = [parent]
+                segment_covering_assignments[(parent, parent)] = [parent]
+                continue
+
+            segment_names: list[str] = []
+            segment_duration_sum = 0
+            penalty = int(parent_half_config.get("penalty", 0))
+            for index, segment in enumerate(segments):
+                if not isinstance(segment, dict):
+                    raise ValueError(f"half_vacations[{parent}].segments[{index}] must be an object")
+                segment_name = segment.get("name")
+                if not segment_name or not isinstance(segment_name, str):
+                    raise ValueError(f"half_vacations[{parent}].segments[{index}].name is required")
+                if segment_name in assignment_metadata:
+                    raise ValueError(f"Duplicate assignable vacation name: {segment_name}")
+                segment_duration = _duration_to_tenths(
+                    segment.get("duration"),
+                    f"half_vacations[{parent}].segments[{index}].duration",
+                )
+                segment_duration_sum += segment_duration
+                segment_names.append(segment_name)
+                half_vacation_names.add(segment_name)
+                segment_is_night = bool(segment.get("is_night", parent_is_night))
+                segment_requires_rest = bool(
+                    segment.get("requires_next_day_rest", segment_is_night or parent_requires_rest)
+                )
+                assignment_metadata[segment_name] = AssignmentMetadata(
+                    name=segment_name,
+                    parent=parent,
+                    duration=segment_duration,
+                    is_half=True,
+                    segment=segment_name,
+                    label=segment.get("label", segment_name),
+                    penalty=penalty,
+                    is_night=segment_is_night,
+                    requires_next_day_rest=segment_requires_rest,
+                )
+                assignable_vacations.append(segment_name)
+                segment_covering_assignments[(parent, segment_name)] = [parent, segment_name]
+
+            if segment_duration_sum != parent_duration:
+                raise ValueError(
+                    f"half_vacations[{parent}] segment durations must sum to "
+                    f"vacation_durations[{parent}]"
+                )
+            coverage_segments[parent] = segment_names
+        else:
+            coverage_segments[parent] = [parent]
+            segment_covering_assignments[(parent, parent)] = [parent]
+
+    return {
+        "coverage_vacations": coverage_vacations,
+        "assignable_vacations": assignable_vacations,
+        "assignment_metadata": assignment_metadata,
+        "coverage_segments": coverage_segments,
+        "segment_covering_assignments": segment_covering_assignments,
+        "half_vacation_names": half_vacation_names,
+    }
+
+
+def _metadata_map(ctx_or_catalog):
+    if isinstance(ctx_or_catalog, dict):
+        return ctx_or_catalog.get("assignment_metadata", {})
+    return getattr(ctx_or_catalog, "assignment_metadata", {})
+
+
+def assignment_parent(ctx, assignment: str) -> str:
+    metadata = _metadata_map(ctx).get(assignment)
+    return metadata.parent if metadata else assignment
+
+
+def is_half_assignment(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.is_half)
+
+
+def is_night_assignment(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.is_night)
+
+
+def requires_next_day_rest(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.requires_next_day_rest)
+
+
+def assignment_matches_choice(ctx, assignment: str, choices: list[str] | set[str]) -> bool:
+    if assignment in choices:
+        return True
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.parent in choices)

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -1,6 +1,13 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+from ..catalog import (
+    assignment_matches_choice,
+    assignment_parent,
+    is_half_assignment,
+    is_night_assignment,
+    requires_next_day_rest,
+)
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
 from ..utils import day_token
@@ -57,7 +64,6 @@ def register(registry: ConstraintRegistry) -> None:
     registry.register_hard(block_unavailable_days)
     registry.register_hard(block_training_days)
     registry.register_hard(block_leave_and_compute_paid_hours)
-    registry.register_hard(limit_day_shifts_per_week)
     registry.register_hard(block_night_before_unavailable)
     registry.register_hard(block_night_before_training)
     registry.register_hard(limit_pre_post_training)
@@ -85,7 +91,7 @@ def apply_initial_shifts(ctx: SolverContext) -> None:
         for day, vacation in shifts:
             if (
                 agent_name in valid_agents
-                and vacation in ctx.vacations
+                and vacation in ctx.assignable_vacations
                 and (day in ctx.previous_week_schedule or day in ctx.week_schedule)
             ):
                 ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 1)
@@ -107,7 +113,7 @@ def limit_one_shift_per_day(ctx: SolverContext) -> None:
         agent_name = agent["name"]
         for day in ctx.week_schedule:
             ctx.model.Add(
-                sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.vacations)
+                sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations)
                 <= 1
             )
 
@@ -129,42 +135,46 @@ def require_at_least_one_shift_per_agent(ctx: SolverContext) -> None:
             sum(
                 ctx.planning[(agent_name, day, vacation)]
                 for day in ctx.week_schedule
-                for vacation in ctx.vacations
+                for vacation in ctx.assignable_vacations
             )
             >= 1
         )
 
 
 def cover_daily_shifts(ctx: SolverContext) -> None:
-    """
-    Covers all daily shifts with configurable staffing per day.
-
-    This constraint is applied per day in the week's schedule.
-    For each day and each configured vacation, it ensures that the number of
-    assigned agents matches staffing_requirements[vacation].
-
-    For days that are part of a weekend or fall on a holiday, and for CDP shifts,
-    it ensures that the sum of all shift variables for all agents on that day is zero.
-    This prevents CDP shifts from being assigned on weekends or holidays.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Covers all parent vacation segments with assignable full/half vacations."""
     for day in ctx.week_schedule:
         day_date = day.split(" ")[1]
         day_is_weekend = day.startswith(("Sam", "Dim"))
-        for vacation in ctx.vacations:
-            required_agents = ctx.staffing_requirements.get(vacation, 1)
-            if vacation == CDP_SHIFT and (day_is_weekend or day_date in ctx.holidays):
+        day_is_holiday = day_date in ctx.holidays
+
+        for assignment in ctx.assignable_vacations:
+            parent = assignment_parent(ctx, assignment)
+            if is_half_assignment(ctx, assignment) and (day_is_weekend or day_is_holiday):
                 ctx.model.Add(
-                    sum(ctx.planning[(agent["name"], day, CDP_SHIFT)] for agent in ctx.agents)
+                    sum(ctx.planning[(agent["name"], day, assignment)] for agent in ctx.agents)
                     == 0
                 )
-            else:
+            if parent == CDP_SHIFT and (day_is_weekend or day_is_holiday):
+                ctx.model.Add(
+                    sum(ctx.planning[(agent["name"], day, assignment)] for agent in ctx.agents)
+                    == 0
+                )
+
+        for vacation in ctx.vacations:
+            required_agents = ctx.staffing_requirements.get(vacation, 1)
+            if vacation == CDP_SHIFT and (day_is_weekend or day_is_holiday):
+                required_agents = 0
+            for segment in ctx.coverage_segments.get(vacation, [vacation]):
+                covering_assignments = ctx.segment_covering_assignments.get(
+                    (vacation, segment), [vacation]
+                )
                 ctx.model.Add(
                     sum(
-                        ctx.planning[(agent["name"], day, vacation)]
+                        ctx.planning[(agent["name"], day, assignment)]
                         for agent in ctx.agents
+                        for assignment in covering_assignments
+                        if assignment in ctx.assignable_vacations
                     )
                     == required_agents
                 )
@@ -187,10 +197,10 @@ def enforce_full_weekend_composition(ctx: SolverContext) -> None:
         for agent in ctx.agents:
             agent_name = agent["name"]
             saturday_work = sum(
-                ctx.planning[(agent_name, day, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations
             )
             sunday_work = sum(
-                ctx.planning[(agent_name, next_day, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, next_day, vacation)] for vacation in ctx.assignable_vacations
             )
             ctx.model.Add(saturday_work == sunday_work)
 
@@ -235,10 +245,10 @@ def enforce_min_free_weekends_per_horizon(ctx: SolverContext) -> None:
                 f"{agent_name}_works_weekend_hard_{saturday}_{sunday}"
             )
             saturday_work = sum(
-                ctx.planning[(agent_name, saturday, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, saturday, vacation)] for vacation in ctx.assignable_vacations
             )
             sunday_work = sum(
-                ctx.planning[(agent_name, sunday, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, sunday, vacation)] for vacation in ctx.assignable_vacations
             )
             ctx.model.Add(saturday_work == 1).OnlyEnforceIf(works_weekend)
             ctx.model.Add(sunday_work == 1).OnlyEnforceIf(works_weekend)
@@ -249,31 +259,25 @@ def enforce_min_free_weekends_per_horizon(ctx: SolverContext) -> None:
         ctx.model.Add(sum(worked_weekend_vars) <= max_worked_weekends)
 
 def avoid_day_after_night(ctx: SolverContext) -> None:
-    """
-    Avoids assigning a day shift after a night shift.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that if the agent is assigned a night shift on a given day,
-    the agent is not assigned a day shift on the next day.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    """Blocks assignments that require rest on the next day."""
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
         agent_name = agent["name"]
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
-            night_var = ctx.planning[(agent_name, day, NIGHT_SHIFT)]
-            for vacation in ctx.vacations:
-                if vacation == NIGHT_SHIFT:
-                    continue
-                ctx.model.Add(ctx.planning[(agent_name, next_day, vacation)] == 0).OnlyEnforceIf(
-                    night_var
-                )
-
+            for rest_assignment in rest_trigger_assignments:
+                rest_var = ctx.planning[(agent_name, day, rest_assignment)]
+                for assignment in ctx.assignable_vacations:
+                    if is_night_assignment(ctx, assignment):
+                        continue
+                    ctx.model.Add(ctx.planning[(agent_name, next_day, assignment)] == 0).OnlyEnforceIf(
+                        rest_var
+                    )
 
 def limit_cdp_per_week(ctx: SolverContext) -> None:
     """
@@ -314,7 +318,7 @@ def block_unavailable_days(ctx: SolverContext) -> None:
         for unavailable_day in unavailable_days:
             for day in ctx.week_schedule:
                 if unavailable_day in day:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 0)
 
 
@@ -336,7 +340,7 @@ def block_training_days(ctx: SolverContext) -> None:
         for training_day in training_days:
             for day in ctx.week_schedule:
                 if training_day in day:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 0)
 
 
@@ -385,7 +389,7 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                         continue
 
                 if vacation_start <= day_date <= vacation_end:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day_str, vacation)] == 0)
                     if day_date.weekday() < 6:
                         leave_paid_hours_by_day[(agent_name, day_str)] = ctx.conge_duration
@@ -399,7 +403,7 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                         weekend_str in ctx.week_schedule
                         or weekend_str in ctx.previous_week_schedule
                     ):
-                        for vacation in ctx.vacations:
+                        for vacation in ctx.assignable_vacations:
                             ctx.model.Add(ctx.planning[(agent_name, weekend_str, vacation)] == 0)
 
     ctx.leave_paid_hours_by_day = leave_paid_hours_by_day
@@ -445,7 +449,10 @@ def block_night_before_unavailable(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
@@ -454,7 +461,8 @@ def block_night_before_unavailable(ctx: SolverContext) -> None:
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
             if any(unavailable_day in next_day for unavailable_day in unavailable_days):
-                ctx.model.Add(ctx.planning[(agent_name, day, NIGHT_SHIFT)] == 0)
+                for assignment in rest_trigger_assignments:
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)
 
 
 def block_night_before_training(ctx: SolverContext) -> None:
@@ -468,7 +476,10 @@ def block_night_before_training(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
@@ -477,21 +488,12 @@ def block_night_before_training(ctx: SolverContext) -> None:
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
             if any(training_day in next_day for training_day in training_days):
-                ctx.model.Add(ctx.planning[(agent_name, day, NIGHT_SHIFT)] == 0)
+                for assignment in rest_trigger_assignments:
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)
 
 
 def limit_pre_post_training(ctx: SolverContext) -> None:
-    """
-    Limits vacation types before and after training days.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that the agent is not assigned any vacation type
-    except for CDP and night shifts on the day after a training day, and that the agent
-    is not assigned any vacation type except for CDP on the day before a training day.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Limits assignment types before and after training days."""
     if not _has_shift(ctx, CDP_SHIFT):
         return
 
@@ -505,19 +507,16 @@ def limit_pre_post_training(ctx: SolverContext) -> None:
 
             if day_idx > 0:
                 previous_day = ctx.week_schedule[day_idx - 1]
-                for vacation in ctx.vacations:
-                    if vacation != CDP_SHIFT:
-                        ctx.model.Add(ctx.planning[(agent_name, previous_day, vacation)] == 0)
+                for assignment in ctx.assignable_vacations:
+                    if assignment_parent(ctx, assignment) != CDP_SHIFT:
+                        ctx.model.Add(ctx.planning[(agent_name, previous_day, assignment)] == 0)
 
             if day_idx < len(ctx.week_schedule) - 1:
                 next_day = ctx.week_schedule[day_idx + 1]
-                allowed_vacations = [CDP_SHIFT]
-                if _has_shift(ctx, NIGHT_SHIFT):
-                    allowed_vacations.append(NIGHT_SHIFT)
-                for vacation in ctx.vacations:
-                    if vacation not in allowed_vacations:
-                        ctx.model.Add(ctx.planning[(agent_name, next_day, vacation)] == 0)
-
+                for assignment in ctx.assignable_vacations:
+                    if assignment_parent(ctx, assignment) == CDP_SHIFT or is_night_assignment(ctx, assignment):
+                        continue
+                    ctx.model.Add(ctx.planning[(agent_name, next_day, assignment)] == 0)
 
 def block_exclusion_days(ctx: SolverContext) -> None:
     """
@@ -538,22 +537,16 @@ def block_exclusion_days(ctx: SolverContext) -> None:
             for day_str in ctx.week_schedule:
                 day_date = day_str.split(" ")[1]
                 if exclusion_day == day_date:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day_str, vacation)] == 0)
 
 
 def block_monday_night_after_weekend_nights(ctx: SolverContext) -> None:
-    """
-    Blocks Monday night shifts after weekend night shifts.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that if the agent is assigned a night shift on a Saturday,
-    the agent is not assigned a night shift on the following Monday.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    """Blocks Monday night assignments after weekend night assignments."""
+    night_assignments = [
+        assignment for assignment in ctx.assignable_vacations if is_night_assignment(ctx, assignment)
+    ]
+    if not night_assignments:
         return
 
     for agent in ctx.agents:
@@ -565,29 +558,24 @@ def block_monday_night_after_weekend_nights(ctx: SolverContext) -> None:
                 if sunday_idx < len(ctx.week_schedule) and monday_idx < len(ctx.week_schedule):
                     sunday = ctx.week_schedule[sunday_idx]
                     monday = ctx.week_schedule[monday_idx]
-                    saturday_night = ctx.planning[(agent_name, day, NIGHT_SHIFT)]
-                    sunday_night = ctx.planning[(agent_name, sunday, NIGHT_SHIFT)]
-                    ctx.model.Add(
-                        ctx.planning[(agent_name, monday, NIGHT_SHIFT)] == 0
-                    ).OnlyEnforceIf(
-                        [saturday_night, sunday_night]
-                    )
-
+                    for saturday_assignment in night_assignments:
+                        for sunday_assignment in night_assignments:
+                            for monday_assignment in night_assignments:
+                                ctx.model.Add(
+                                    ctx.planning[(agent_name, monday, monday_assignment)] == 0
+                                ).OnlyEnforceIf(
+                                    [
+                                        ctx.planning[(agent_name, day, saturday_assignment)],
+                                        ctx.planning[(agent_name, sunday, sunday_assignment)],
+                                    ]
+                                )
 
 def apply_agent_restrictions(ctx: SolverContext) -> None:
-    """
-    Applies agent-specific vacation restrictions.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that the agent is not assigned any restricted vacation type
-    on any day of the week.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Applies agent-specific vacation/assignment restrictions."""
     for agent in ctx.agents:
         agent_name = agent["name"]
-        restricted_vacations = agent.get("restriction", [])
+        restricted_vacations = set(agent.get("restriction", []))
         for day in ctx.week_schedule:
-            for restricted_vacation in restricted_vacations:
-                ctx.model.Add(ctx.planning[(agent_name, day, restricted_vacation)] == 0)
+            for assignment in ctx.assignable_vacations:
+                if assignment_matches_choice(ctx, assignment, restricted_vacations):
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -16,35 +16,26 @@ def register(registry: ConstraintRegistry) -> None:
     :param registry: The registry to which the constraints should be registered.
     :type registry: ConstraintRegistry
     """
-    registry.register_mixed(limit_weekly_nights_and_hours)
+    registry.register_mixed(limit_weekly_worked_hours)
 
 
-def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
-    """
-    Limits weekly night shifts and total worked hours.
-
-    This constraint is applied per agent and per week in the week's schedule.
-    For each agent, it allows at most 3 night shifts per week and caps worked
-    hours using solver.max_weekly_hours. The worked-hours cap counts all
-    configured vacations assigned by the solver and does not include paid leave.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+def limit_weekly_worked_hours(ctx: SolverContext) -> None:
+    """Caps weekly worked hours using solver.max_weekly_hours."""
     for agent in ctx.agents:
         agent_name = agent["name"]
 
         for week in ctx.weeks_split:
-            if NIGHT_SHIFT in ctx.vacations:
-                ctx.model.Add(
-                    sum(ctx.planning[(agent_name, day, NIGHT_SHIFT)] for day in week) <= 3
-                )
-
+            assignable_vacations = getattr(ctx, "assignable_vacations", None) or ctx.vacations
             total_hours = sum(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in ctx.vacations
+                    for vacation in assignable_vacations
                 )
                 for day in week
             )
             ctx.model.Add(total_hours <= ctx.max_weekly_hours)
+
+
+def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
+    """Backward-compatible alias for the weekly worked-hours cap."""
+    limit_weekly_worked_hours(ctx)

--- a/backend/solver/constraints/soft.py
+++ b/backend/solver/constraints/soft.py
@@ -1,5 +1,6 @@
 from ortools.sat.python import cp_model
 
+from ..catalog import assignment_parent
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
 from ..utils import split_by_month_or_period
@@ -22,7 +23,7 @@ def _assignment_sum(ctx: SolverContext, agent_name: str, day: str, vacations: li
     :return: The sum of assignments for the given agent, day, and list of vacations.
     :rtype: int
     """
-    relevant = [vacation for vacation in vacations if vacation in ctx.vacations]
+    relevant = [vacation for vacation in vacations if vacation in ctx.assignable_vacations]
     if not relevant:
         return 0
     return sum(ctx.planning[(agent_name, day, vacation)] for vacation in relevant)
@@ -41,10 +42,14 @@ def _working_vacations(ctx: SolverContext) -> list[str]:
     :return: A list of working vacations.
     :rtype: list[str]
     """
-    vacations = [vacation for vacation in ctx.vacations if vacation != CDP_SHIFT]
+    vacations = [
+        vacation
+        for vacation in ctx.assignable_vacations
+        if assignment_parent(ctx, vacation) != CDP_SHIFT
+    ]
     if vacations:
         return vacations
-    return list(ctx.vacations)
+    return list(ctx.assignable_vacations)
 
 
 def register(registry: ConstraintRegistry) -> None:
@@ -81,7 +86,7 @@ def balance_paid_hours(ctx: SolverContext) -> None:
             list(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in ctx.vacations
+                    for vacation in ctx.assignable_vacations
                 )
                 + _leave_paid_hours(ctx, agent_name, day)
                 for day in ctx.week_schedule
@@ -120,7 +125,7 @@ def balance_paid_hours_by_period(ctx: SolverContext) -> None:
                 list(
                     sum(
                         ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                        for vacation in ctx.vacations
+                        for vacation in ctx.assignable_vacations
                     )
                     + _leave_paid_hours(ctx, agent_name, day)
                     for day in period

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Tuple
 
+from .catalog import AssignmentMetadata
+
 from ortools.sat.python import cp_model
 
 
@@ -62,6 +64,11 @@ class SolverContext:
     planning: Dict[Tuple[str, str, str], cp_model.IntVar] = field(default_factory=dict)
     leave_paid_hours_by_day: Dict[Tuple[str, str], int] = field(default_factory=dict)
     day_dates: Dict[str, datetime] = field(default_factory=dict)
+    assignable_vacations: List[str] = field(default_factory=list)
+    assignment_metadata: Dict[str, AssignmentMetadata] = field(default_factory=dict)
+    coverage_segments: Dict[str, List[str]] = field(default_factory=dict)
+    segment_covering_assignments: Dict[Tuple[str, str], List[str]] = field(default_factory=dict)
+    half_vacation_names: set[str] = field(default_factory=set)
 
     shift_durations: Dict[str, int] = field(default_factory=dict)
     staffing_requirements: Dict[str, int] = field(default_factory=dict)

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from ortools.sat.python import cp_model
 
+from .catalog import build_vacation_catalog
 from .constraints import hard, mixed, soft
 from .context import SolverContext
 from .objective import apply_objective
@@ -22,7 +23,7 @@ def _build_planning_variables(ctx: SolverContext) -> None:
     for agent in ctx.agents:
         agent_name = agent["name"]
         for day in set(ctx.week_schedule + ctx.previous_week_schedule):
-            for vacation in ctx.vacations:
+            for vacation in ctx.assignable_vacations:
                 ctx.planning[(agent_name, day, vacation)] = ctx.model.NewBoolVar(
                     f"planning_{agent_name}_{day}_{vacation}"
                 )
@@ -67,21 +68,18 @@ def _load_shift_durations(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    configured_durations = ctx.config["vacation_durations"]
-    missing_vacation_durations = [
-        vacation for vacation in ctx.vacations if vacation not in configured_durations
-    ]
-    if missing_vacation_durations:
-        missing_joined = ", ".join(sorted(missing_vacation_durations))
-        raise ValueError(
-            "Missing vacation_durations entries for configured vacations: "
-            f"{missing_joined}"
-        )
+    catalog = build_vacation_catalog(ctx.config)
+    ctx.assignable_vacations = catalog["assignable_vacations"]
+    ctx.assignment_metadata = catalog["assignment_metadata"]
+    ctx.coverage_segments = catalog["coverage_segments"]
+    ctx.segment_covering_assignments = catalog["segment_covering_assignments"]
+    ctx.half_vacation_names = catalog["half_vacation_names"]
 
     ctx.shift_durations = {
-        vacation: int(configured_durations[vacation] * 10) for vacation in ctx.vacations
+        vacation: metadata.duration
+        for vacation, metadata in ctx.assignment_metadata.items()
     }
-    ctx.conge_duration = int(ctx.config["vacation_durations"]["Conge"] * 10)
+    ctx.conge_duration = int(round(ctx.config["vacation_durations"]["Conge"] * 10))
 
     staffing_config = ctx.config.get("staffing_requirements", {})
     ctx.staffing_requirements = {}
@@ -156,7 +154,7 @@ def _extract_solution(ctx: SolverContext, solver: cp_model.CpSolver):
         agent_name = agent["name"]
         result[agent_name] = []
         for day in ctx.week_schedule:
-            for vacation in ctx.vacations:
+            for vacation in ctx.assignable_vacations:
                 if solver.Value(ctx.planning[(agent_name, day, vacation)]):
                     result[agent_name].append((day, vacation))
     return result
@@ -192,6 +190,8 @@ def generate_planning(
     :return: A dictionary containing the generated planning, where each key is an agent name and each value is a list of tuples, where each tuple contains a day and a vacation type.
     :rtype: Dict[str, List[Tuple[str, str]]]
     """
+    runtime_config = dict(runtime_config)
+    runtime_config.setdefault("vacations", vacations)
     model = cp_model.CpModel()
     ctx = SolverContext(
         model=model,

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -1,5 +1,6 @@
 from ortools.sat.python import cp_model
 
+from .catalog import assignment_matches_choice, is_half_assignment
 from .context import SolverContext
 
 
@@ -21,8 +22,8 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_preferred
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation in agent["preferences"]["preferred"]
+            for vacation in ctx.assignable_vacations
+            if assignment_matches_choice(ctx, vacation, agent["preferences"]["preferred"])
         )
     )
 
@@ -31,8 +32,8 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_other
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation not in agent["preferences"]["preferred"]
+            for vacation in ctx.assignable_vacations
+            if not assignment_matches_choice(ctx, vacation, agent["preferences"]["preferred"])
         )
     )
 
@@ -41,8 +42,19 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_avoid
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation in agent["preferences"]["avoid"]
+            for vacation in ctx.assignable_vacations
+            if assignment_matches_choice(ctx, vacation, agent["preferences"]["avoid"])
+        )
+    )
+
+    half_vacation_penalties = cp_model.LinearExpr.Sum(
+        list(
+            ctx.planning[(agent["name"], day, vacation)]
+            * ctx.assignment_metadata[vacation].penalty
+            for agent in ctx.agents
+            for day in ctx.week_schedule
+            for vacation in ctx.assignable_vacations
+            if is_half_assignment(ctx, vacation)
         )
     )
 
@@ -50,6 +62,7 @@ def apply_objective(ctx: SolverContext) -> None:
         objective_preferred_vacations
         + objective_other_vacations
         + penalized_vacations
+        - half_vacation_penalties
         - ctx.weekend_balancing_objective
     )
     if ctx.optimize_period_balance:

--- a/backend/tests/test_half_vacations.py
+++ b/backend/tests/test_half_vacations.py
@@ -1,0 +1,126 @@
+from app import get_week_schedule, validate_runtime_config
+from solver.catalog import build_vacation_catalog
+from solver.engine import generate_planning
+
+
+def _agent(name, preferred=None, restriction=None, unavailable=None):
+    return {
+        "name": name,
+        "preferences": {"preferred": preferred or ["Jour"], "avoid": []},
+        "restriction": restriction or [],
+        "unavailable": unavailable or [],
+        "training": [],
+        "exclusion": [],
+        "vacations": [],
+    }
+
+
+def _runtime_config():
+    return {
+        "agents": [
+            _agent("Agent1"),
+            _agent("Agent2"),
+        ],
+        "vacations": ["Jour"],
+        "staffing_requirements": {"Jour": 1},
+        "vacation_durations": {"Jour": 12, "Conge": 7},
+        "half_vacations": {
+            "Jour": {
+                "enabled": True,
+                "penalty": 500,
+                "segments": [
+                    {"name": "Jour matin", "label": "J matin", "duration": 6},
+                    {"name": "Jour après-midi", "label": "J aprem", "duration": 6},
+                ],
+            }
+        },
+        "vacation_colors": {
+            "Jour": "#75FA79",
+            "Jour matin": "#B9F6CA",
+            "Jour après-midi": "#00C853",
+        },
+        "holidays": [],
+        "solver": {
+            "max_time_seconds": 30,
+            "relative_gap_limit": 0.1,
+            "num_search_workers": 0,
+            "global_max_gap": 240,
+            "period_max_gap": 240,
+            "max_weekly_hours": 42,
+            "optimize_period_balance": False,
+            "period_balance_weight": 2,
+            "min_free_weekends_per_horizon": 0,
+        },
+    }
+
+
+def test_half_vacation_config_validates_and_builds_assignable_catalog():
+    config = _runtime_config()
+
+    assert validate_runtime_config(config) == []
+    catalog = build_vacation_catalog(config)
+
+    assert catalog["coverage_vacations"] == ["Jour"]
+    assert catalog["assignable_vacations"] == ["Jour", "Jour matin", "Jour après-midi"]
+    assert catalog["assignment_metadata"]["Jour matin"].parent == "Jour"
+    assert catalog["assignment_metadata"]["Jour matin"].duration == 60
+    assert catalog["segment_covering_assignments"][("Jour", "Jour matin")] == [
+        "Jour",
+        "Jour matin",
+    ]
+
+
+def test_half_vacation_config_rejects_duration_mismatch():
+    config = _runtime_config()
+    config["half_vacations"]["Jour"]["segments"][1]["duration"] = 5
+
+    errors = validate_runtime_config(config)
+
+    assert errors
+    assert "segment durations must sum" in errors[0]["message"]
+
+
+def test_solver_can_cover_parent_with_complementary_half_vacations():
+    config = _runtime_config()
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-05")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" not in result
+    assignments = [vacation for shifts in result.values() for _, vacation in shifts]
+    assert sorted(assignments) == ["Jour après-midi", "Jour matin"]
+
+
+def test_half_vacations_are_forbidden_on_weekends():
+    config = _runtime_config()
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-10", "2026-01-10")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-10",
+    )
+
+    assert "info" in result

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -407,7 +407,7 @@ def test_diagnose_manual_entry_conflicts_detects_understaffed_shift_capacity():
     staffing_reason = next(
         reason for reason in reasons if reason["code"] == "STAFFING_REQUIREMENT_UNMET"
     )
-    assert staffing_reason["count"] == 1
+    assert staffing_reason["count"] == 2
     assert "2026-01-15 / Jour" in staffing_reason["details"][0]
 
 
@@ -446,9 +446,10 @@ def test_diagnose_manual_entry_conflicts_detects_manual_overstaffing():
     assert "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT" in reason_codes
 
 
-def test_diagnose_manual_entry_conflicts_detects_day_shift_weekly_limit():
+def test_diagnose_manual_entry_conflicts_does_not_emit_day_shift_weekly_quota():
     config = deepcopy(load_default_config())
     agent_name = config["agents"][0]["name"]
+    config["solver"]["max_weekly_hours"] = 48
     entries = [
         {
             "agent": agent_name,
@@ -462,14 +463,8 @@ def test_diagnose_manual_entry_conflicts_detects_day_shift_weekly_limit():
 
     reasons = _diagnose_manual_entry_conflicts(entries, config)
 
-    weekly_limit_reason = next(
-        reason
-        for reason in reasons
-        if reason["code"] == "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"
-    )
-    assert weekly_limit_reason["count"] == 1
-    assert "4 vacations Jour" in weekly_limit_reason["details"][0]
-
+    reason_codes = [reason["code"] for reason in reasons]
+    assert "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED" not in reason_codes
 
 def test_diagnose_manual_entry_conflicts_detects_shift_after_night():
     config = deepcopy(load_default_config())

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -171,7 +171,7 @@
               >
                 <select v-model="selectedShifts[agent.name][day]">
                   <option value="">-</option>
-                  <option v-for="vacation in vacations" :key="vacation" :value="vacation">
+                  <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
                     {{ vacation }}
                   </option>
                 </select>
@@ -203,7 +203,7 @@
                 >
                   <select v-model="manualSelectedShifts[agent.name][day]">
                     <option value="">-</option>
-                    <option v-for="vacation in vacations" :key="vacation" :value="vacation">
+                    <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
                       {{ vacation }}
                     </option>
                     <option value="status:unavailable">Indisponible</option>
@@ -388,6 +388,7 @@ export default {
       previousWeekSchedule: [],
       agents: [],
       vacations: ['Jour', 'Nuit', 'CDP'],
+      assignableVacationsData: ['Jour', 'Nuit', 'CDP'],
       selectedShifts: {},
       manualWeekSchedule: [],
       manualSelectedShifts: {},
@@ -415,6 +416,12 @@ export default {
           Jour: 1,
           Nuit: 1,
           CDP: 1
+        },
+        half_vacations: {},
+        vacation_colors: {
+          Jour: '#75FA79',
+          Nuit: '#9175FA',
+          CDP: '#A59384'
         },
         holidays: [],
         solver: {}
@@ -473,12 +480,31 @@ export default {
     },
     restrictionTypesDurations() {
       return this.restrictionDurationsFromConfig || this.configData?.restriction_types_durations || {};
+    },
+    assignableVacations() {
+      return this.assignableVacationsData?.length ? this.assignableVacationsData : this.vacations;
     }
   },
   methods: {
     resetMessages() {
       this.errorMessage = null;
       this.infoMessage = null;
+    },
+
+    buildAssignableVacations(config) {
+      const assignable = [...(config?.vacations || [])];
+      const seen = new Set(assignable);
+      Object.entries(config?.half_vacations || {}).forEach(([parent, halfConfig]) => {
+        if (!seen.has(parent) || halfConfig?.enabled === false) return;
+        (halfConfig.segments || []).forEach((segment) => {
+          const name = segment?.name;
+          if (name && !seen.has(name)) {
+            seen.add(name);
+            assignable.push(name);
+          }
+        });
+      });
+      return assignable;
     },
     resetPlanningData() {
       this.planningResult = null;
@@ -507,6 +533,8 @@ export default {
       normalized.holidays = Array.isArray(normalized.holidays) ? normalized.holidays : [];
       normalized.solver = normalized.solver || {};
       normalized.restriction_types_durations = normalized.restriction_types_durations || {};
+      normalized.half_vacations = normalized.half_vacations || {};
+      normalized.vacation_colors = normalized.vacation_colors || {};
 
       normalized.vacations = normalized.vacations.map((value) => String(value).trim()).filter(Boolean);
       normalized.vacations.forEach((vacation) => {
@@ -540,6 +568,8 @@ export default {
       this.vacationsInput = normalized.vacations.join(', ');
       this.holidaysInput = normalized.holidays.join(', ');
       this.vacations = [...normalized.vacations];
+      this.assignableVacationsData = this.buildAssignableVacations(normalized);
+      this.vacationColors = { ...this.vacationColors, ...normalized.vacation_colors };
       this.agents = [...normalized.agents];
       this.restrictionDurationsFromConfig = normalized.restriction_types_durations;
       await this.$nextTick();
@@ -578,6 +608,8 @@ export default {
 
       payload.vacation_durations = payload.vacation_durations || {};
       payload.staffing_requirements = payload.staffing_requirements || {};
+      payload.half_vacations = payload.half_vacations || {};
+      payload.vacation_colors = payload.vacation_colors || {};
 
       payload.vacations.forEach((vacation) => {
         const duration = Number(payload.vacation_durations[vacation]);
@@ -663,7 +695,11 @@ export default {
         if (this.configData.staffing_requirements[vacation] == null) {
           this.configData.staffing_requirements[vacation] = 1;
         }
+        if (this.configData.vacation_colors?.[vacation] == null) {
+          this.configData.vacation_colors[vacation] = this.vacationColors[vacation] || '#ffffff';
+        }
       });
+      this.assignableVacationsData = this.buildAssignableVacations(this.configData);
     },
     setVacationDuration(vacation, value) {
       const parsed = Number(value);
@@ -723,6 +759,7 @@ export default {
         });
         this.previousWeekSchedule = response.data.previous_week_schedule;
         this.agents = response.data.agents || [];
+        this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.selectedShifts = {};
         this.agents.forEach((agent) => {
           if (!agent.name) {
@@ -821,6 +858,8 @@ export default {
         const response = await apiPost(endpoint, payload);
         this.planningResult = response.data.planning;
         this.vacationDurations = response.data.vacation_durations;
+        this.vacationColors = { ...this.vacationColors, ...(response.data.vacation_colors || {}) };
+        this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.weekSchedule = response.data.week_schedule;
         this.holidaysFromConfig = response.data.holidays;
         this.unavailableFromConfig = response.data.unavailable;

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -13,7 +13,7 @@
           <tr>
             <th>Agent</th>
             <th v-for="day in monthDays" :key="day">{{ day }}</th>
-            <th>Total Vacations</th>
+            <th>Total affectations</th>
             <th>Total Heures</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Objective

Add support for half-vacations in scheduling generation and existing-schedule optimization, allowing weekday coverage to be split into assignable half-day or half-night segments while preserving existing full-vacation behavior.

## Breaking Change Notice

No API breaking change.

Existing configurations without `half_vacations` keep their current behavior. New optional configuration fields allow half-vacations, vacation colors, vacation metadata, and configurable penalties.

## Scope

- Add backend vacation catalog normalization for:
  - full vacations
  - assignable half-vacations
  - coverage segments
  - durations
  - penalties
  - night/rest metadata
- Extend configuration support for `half_vacations`, `vacation_colors`, and optional vacation metadata.
- Update solver constraints to cover each required segment either with a full vacation or the matching half-vacation.
- Forbid half-vacations on weekends and holidays.
- Add configurable soft penalty for half-vacation usage.
- Preserve weekly worked-hours cap behavior without adding a hard night quota.
- Expose assignable vacations, configured colors, enriched durations, and segmented capacity diagnostics through the API.
- Update the frontend to select and display assignable half-vacations in planning and existing-schedule optimization flows.
- Rename `Total Vacations` to `Total affectations`.
- Add backend tests for half-vacation validation, duration consistency, complementary segment coverage, and weekend rejection.

## Validation

- `python -m pytest backend/tests -q`
- `npm test -- --runInBand` from `frontend/`
- `npm run build` from `frontend/`

## Results

- Backend test suite passes.
- Frontend tests pass.
- Frontend production build succeeds.

## Risks and Mitigations

- Risk: half-vacations can increase solver search space and affect optimization choices.
- Mitigation: usage is optional and controlled by configuration, with a configurable soft penalty.

- Risk: invalid half-vacation segment definitions could create impossible coverage.
- Mitigation: catalog validation rejects inconsistent segment definitions and durations.

- Risk: half-vacations may be selected in contexts where they should not be allowed.
- Mitigation: solver constraints explicitly reject half-vacations on weekends and holidays.