### PR TITLE
Frontend display

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -172,7 +172,7 @@
                 <select v-model="selectedShifts[agent.name][day]">
                   <option value="">-</option>
                   <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
-                    {{ vacation }}
+                    {{ getAssignmentLabel(vacation) }}
                   </option>
                 </select>
               </td>
@@ -204,7 +204,7 @@
                   <select v-model="manualSelectedShifts[agent.name][day]">
                     <option value="">-</option>
                     <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
-                      {{ vacation }}
+                      {{ getAssignmentLabel(vacation) }}
                     </option>
                     <option value="status:unavailable">Indisponible</option>
                     <option value="status:training">Formation</option>
@@ -279,6 +279,23 @@
         </ul>
       </div>
 
+      <div v-if="isExistingOptimizationMode && optimizationModifiedAssignments.length" class="info-card">
+        <span class="info-icon">i</span>
+        <div>
+          <strong>Affectations existantes modifiées</strong>
+          <ul class="modified-list">
+            <li
+              v-for="(modification, index) in optimizationModifiedAssignments"
+              :key="`mod_${index}`"
+            >
+              {{ modification.agent }} - {{ modification.date || modification.day }} :
+              {{ getAssignmentLabel(modification.initial_value) }} -> {{ getAssignmentLabel(modification.final_value) || 'cellule vidée' }}
+              ({{ formatModificationType(modification.change_type) }})
+            </li>
+          </ul>
+        </div>
+      </div>
+
       <div>
         <button @click="generatePlanning" :disabled="isLoading || isConfigSaving">
           {{ isLoading ? "Génération en cours..." : actionButtonLabel }}
@@ -301,7 +318,8 @@
           :dayOff="dayOffFromConfig"
           :training="trainingFromConfig"
           :restrictions="restrictionsFromConfig"
-          :restrictionsDurations="restrictionDurationsFromConfig"
+          :restrictionDurations="restrictionDurationsFromConfig"
+          :assignmentLabels="assignmentLabels"
           :planningStartDate="startDate"
         />
       </div>
@@ -370,6 +388,7 @@ export default {
       endDate: null,
       planningResult: null,
       vacationDurations: null,
+      assignmentLabels: {},
       weekSchedule: [],
       vacationColors: {
         Jour: '#75FA79',
@@ -396,6 +415,7 @@ export default {
       optimizationSuggestions: [],
       optimizationBlockingReasons: [],
       optimizationImpactedCells: [],
+      optimizationModifiedAssignments: [],
       optimizationMeta: null,
       optimizationStatus: null,
       isLoading: false,
@@ -509,6 +529,7 @@ export default {
     resetPlanningData() {
       this.planningResult = null;
       this.vacationDurations = null;
+      this.assignmentLabels = {};
       this.weekSchedule = [];
       this.holidaysFromConfig = [];
       this.unavailableFromConfig = null;
@@ -522,6 +543,7 @@ export default {
       this.optimizationStatus = null;
       this.optimizationBlockingReasons = [];
       this.optimizationImpactedCells = [];
+      this.optimizationModifiedAssignments = [];
     },
     async applyConfigToState(config) {
       this.isHydratingConfig = true;
@@ -701,6 +723,18 @@ export default {
       });
       this.assignableVacationsData = this.buildAssignableVacations(this.configData);
     },
+    getAssignmentLabel(assignment) {
+      if (!assignment) return '';
+      return this.assignmentLabels?.[assignment] || assignment;
+    },
+    formatModificationType(changeType) {
+      const labels = {
+        changed_to_full: 'remplacée par vacation complète',
+        changed_to_half: 'remplacée par demi-vacation',
+        cleared: 'vidée'
+      };
+      return labels[changeType] || changeType || 'modifiée';
+    },
     setVacationDuration(vacation, value) {
       const parsed = Number(value);
       this.configData.vacation_durations[vacation] = Number.isFinite(parsed) ? parsed : 1;
@@ -858,6 +892,7 @@ export default {
         const response = await apiPost(endpoint, payload);
         this.planningResult = response.data.planning;
         this.vacationDurations = response.data.vacation_durations;
+        this.assignmentLabels = response.data.assignment_labels || {};
         this.vacationColors = { ...this.vacationColors, ...(response.data.vacation_colors || {}) };
         this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.weekSchedule = response.data.week_schedule;
@@ -871,6 +906,7 @@ export default {
         this.optimizationSuggestions = response.data.suggestions || [];
         this.optimizationBlockingReasons = response.data.blocking_reasons || [];
         this.optimizationImpactedCells = response.data.impacted_cells || [];
+        this.optimizationModifiedAssignments = response.data.modified_existing_assignments || [];
         this.optimizationMeta = response.data.meta || null;
         this.optimizationStatus = response.data.status || null;
       } catch (error) {
@@ -881,6 +917,7 @@ export default {
           this.optimizationSuggestions = responseData.suggestions || [];
           this.optimizationBlockingReasons = responseData.blocking_reasons || [];
           this.optimizationImpactedCells = responseData.impacted_cells || [];
+          this.optimizationModifiedAssignments = responseData.modified_existing_assignments || [];
           this.optimizationMeta = responseData.meta || null;
           this.infoMessage = responseData.error || "Aucune solution trouvée. Consultez les suggestions.";
         } else if (responseData?.info) {
@@ -1112,6 +1149,11 @@ button:disabled {
   color: #8a0000;
   font-size: 14px;
   margin-top: 4px;
+}
+
+.modified-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
 }
 
 .info-card {

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -20,8 +20,13 @@
         <tbody>
           <tr v-for="(agent, index) in Object.keys(planning)" :key="index">
             <td>{{ agent }}</td>
-            <td v-for="day in monthDays" :key="day" :style="{ backgroundColor: getColumnColor(agent, day) }">
-              {{ getVacationForAgent(agent, day) || '//' }}
+            <td
+              v-for="day in monthDays"
+              :key="day"
+              :style="{ backgroundColor: getColumnColor(agent, day) }"
+              :title="getCellTitle(agent, day)"
+            >
+              {{ getDisplayValueForAgent(agent, day) || '//' }}
             </td>
             <td>{{ calculateNumberShifts(agent, monthDays) }}</td>
             <td>{{ calculateTotalHours(agent, monthDays) }} h</td>
@@ -73,6 +78,11 @@ export default {
       default: () => ({})
     },
     restrictionDurations: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    },
+    assignmentLabels: {
       type: Object,
       required: false,
       default: () => ({})
@@ -231,6 +241,30 @@ export default {
       }
       return this.planningLookup?.[agent]?.[day] || null;
     },
+    getWorkedAssignmentForAgent(agent, day) {
+      return this.planningLookup?.[agent]?.[day] || null;
+    },
+    getAssignmentLabel(assignment) {
+      return this.assignmentLabels?.[assignment] || assignment;
+    },
+    getDisplayValueForAgent(agent, day) {
+      const statusOrVacation = this.getVacationForAgent(agent, day);
+      if (!statusOrVacation) {
+        return null;
+      }
+      const workedAssignment = this.getWorkedAssignmentForAgent(agent, day);
+      if (workedAssignment && statusOrVacation === workedAssignment) {
+        return this.getAssignmentLabel(workedAssignment);
+      }
+      return statusOrVacation;
+    },
+    getCellTitle(agent, day) {
+      const workedAssignment = this.getWorkedAssignmentForAgent(agent, day);
+      if (workedAssignment && this.assignmentLabels?.[workedAssignment]) {
+        return workedAssignment;
+      }
+      return this.getVacationForAgent(agent, day) || '';
+    },
     isVacationDay(agent, day) {
       const vacations = this.dayOff?.[agent] || [];
       const dayDate = this.resolveDayDate(day);
@@ -325,12 +359,12 @@ export default {
         if (restriction && this.restrictionDurations?.[restriction.type]) {
           return total + this.restrictionDurations[restriction.type];
         }
-        const vacation = this.getVacationForAgent(agent, day);
+        const vacation = this.getWorkedAssignmentForAgent(agent, day);
         return total + (this.vacationDurations[vacation] || 0);
       }, 0);
     },
     calculateNumberShifts(agent, days) {
-      return days.filter((day) => this.getVacationForAgent(agent, day)).length;
+      return days.filter((day) => this.getWorkedAssignmentForAgent(agent, day)).length;
     }
   }
 };

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -1,0 +1,65 @@
+import { shallowMount } from '@vue/test-utils';
+import App from '../src/App.vue';
+
+jest.mock('../src/apiClient', () => ({
+  apiGet: jest.fn(() => Promise.resolve({
+    data: {
+      agents: [],
+      vacations: ['Jour', 'Nuit'],
+      vacation_durations: {
+        Jour: 12,
+        Nuit: 12,
+        Conge: 7,
+      },
+      staffing_requirements: {
+        Jour: 1,
+        Nuit: 1,
+      },
+      holidays: [],
+      solver: {},
+      half_vacations: {},
+      vacation_colors: {},
+    },
+  })),
+  apiPost: jest.fn(),
+  apiPut: jest.fn(),
+  normalizeApiError: jest.fn((error, fallback) => fallback),
+}));
+
+describe('App.vue', () => {
+  it('renders modified existing assignments with labels', async () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      activeMode: 'planning',
+      generationMode: 'existing',
+      assignmentLabels: {
+        'Jour matin': 'J matin',
+      },
+      optimizationModifiedAssignments: [
+        {
+          agent: 'Agent1',
+          date: '2026-01-05',
+          initial_value: 'Jour matin',
+          final_value: 'Nuit',
+          change_type: 'changed_to_full',
+        },
+      ],
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain('Agent1');
+    expect(text).toContain('J matin');
+    expect(text).toContain('Nuit');
+    expect(text).toContain('2026-01-05');
+  });
+});

--- a/frontend/tests/PlanningTable.spec.js
+++ b/frontend/tests/PlanningTable.spec.js
@@ -139,4 +139,42 @@ describe('PlanningTable.vue', () => {
     expect(text).not.toContain('Jour');
     expect(text).not.toContain('Nuit');
   });
+
+  it('uses assignment labels while keeping worked-hour and worked-assignment totals', () => {
+    const wrapper = shallowMount(PlanningTable, {
+      props: {
+        planning: {
+          Agent1: [['Lun. 05-01', 'Jour matin']],
+        },
+        weekSchedule: ['Lun. 05-01', 'Mar. 06-01'],
+        vacationDurations: {
+          'Jour matin': 6,
+        },
+        vacationColors: {
+          'Jour matin': '#B9F6CA',
+        },
+        assignmentLabels: {
+          'Jour matin': 'J matin',
+        },
+        holidays: [],
+        unavailable: {
+          Agent1: ['06-01-2026'],
+        },
+        dayOff: {
+          Agent1: [],
+        },
+        training: {
+          Agent1: [],
+        },
+        planningStartDate: '2026-01-05',
+      },
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain('J matin');
+    expect(text).toContain('Ind.');
+    expect(text).toContain('1');
+    expect(text).toContain('6 h');
+    expect(wrapper.find('tbody td[title="Jour matin"]').exists()).toBe(true);
+  });
 });


### PR DESCRIPTION
## Objective

Improve frontend planning display for half-vacations and existing-schedule optimization results by using backend assignment labels, showing modified existing assignments, and making planning totals reflect worked assignments only.

## Breaking Change Notice

No API breaking change.

The frontend now consumes the additive `assignment_labels` and `modified_existing_assignments` fields when available. Existing responses without these fields still fall back to assignment names and no modification panel.

## Scope

- Display short assignment labels from `assignment_labels` in the planning table.
- Keep the full assignment name available as a cell tooltip.
- Use assignment labels in continuity and existing-optimization selection menus.
- Show modified existing assignments after existing-schedule optimization.
- Format modification types for:
  - changed to full vacation
  - changed to half-vacation
  - cleared cell
- Fix `Total affectations` so it counts only worked assignments, not statuses such as `Ind.`, `Con.`, `For.`, or `Res.`.
- Keep `Total Heures` based on the actual worked assignment duration, including half-vacations.
- Fix the `restrictionDurations` prop binding passed to `PlanningTable`.
- Add frontend tests for assignment labels, tooltip behavior, worked totals, and modified existing assignments.

## Validation

- `npm test -- --runInBand` from `frontend/`
- `npm run build` from `frontend/`
- `npm run lint` from `frontend/`
- `backend/.venv/Scripts/python.exe -m pytest backend/tests -q`

## Results

- Frontend test suite passes: `9 passed`.
- Frontend production build succeeds.
- Frontend lint passes with no errors.
- Backend test suite passes: `117 passed`.

## Risks and Mitigations

- Risk: assignment labels may be missing from older backend responses.
- Mitigation: the frontend falls back to the raw assignment name.

- Risk: users may expect status cells to count in `Total affectations`.
- Mitigation: `Total Heures` remains the main workload indicator, while `Total affectations` now matches worked assignments only.

- Risk: modified existing assignments could clutter optimization results.
- Mitigation: the section only appears when the backend reports modifications.