### PR TITLE
Consolidate half-vacation configuration UX and docs

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -75,7 +75,108 @@ Allowed shift names:
 
 - Type: object keyed by parent vacation name.
 - Purpose: define assignable segments that can cover a parent vacation segment by segment.
+- A parent vacation remains assignable as a full vacation.
+- Each segment is also assignable when its parent is enabled.
+- Daily coverage is checked segment by segment:
+  - a full parent assignment covers every segment;
+  - a segment assignment covers only its matching segment.
+- `staffing_requirements[parent] = N` means each segment of that parent must be covered `N` times.
+- Half-vacations are rejected on weekends and recurring holidays.
 - `CDP` is intentionally not splittable; `half_vacations.CDP` is rejected at runtime.
+
+Example:
+
+```json
+"half_vacations": {
+  "Jour": {
+    "enabled": true,
+    "penalty": 500,
+    "segments": [
+      {
+        "name": "Jour matin",
+        "label": "J matin",
+        "duration": 6
+      },
+      {
+        "name": "Jour apres-midi",
+        "label": "J aprem",
+        "duration": 6
+      }
+    ]
+  },
+  "Nuit": {
+    "enabled": true,
+    "penalty": 700,
+    "segments": [
+      {
+        "name": "Nuit debut",
+        "label": "N debut",
+        "duration": 6,
+        "is_night": true,
+        "requires_next_day_rest": true
+      },
+      {
+        "name": "Nuit fin",
+        "label": "N fin",
+        "duration": 6,
+        "is_night": true,
+        "requires_next_day_rest": true
+      }
+    ]
+  }
+}
+```
+
+Validation rules:
+
+- `segments` must contain at least two valid entries.
+- segment names must be unique across all assignable vacations.
+- each segment duration must be positive.
+- segment durations must sum to the parent duration in `vacation_durations`.
+- `penalty` is a soft objective penalty: higher values make half-vacations less preferred without making them impossible.
+
+### `vacation_colors` (optional)
+
+- Type: object of `{ "<assignable_vacation_name>": "#RRGGBB" }`
+- Purpose: frontend display colors for full vacations and half-vacation segments.
+- Colors must be six-digit hex values.
+- Parent vacation colors are recommended.
+- Segment colors are optional but recommended for readability.
+- The frontend configuration editor saves colors only for active vacations and saved segments.
+
+Example:
+
+```json
+"vacation_colors": {
+  "Jour": "#75FA79",
+  "Jour matin": "#B9F6CA",
+  "Jour apres-midi": "#00C853",
+  "Nuit": "#9175FA"
+}
+```
+
+### `vacation_metadata` (optional)
+
+- Type: object keyed by parent vacation name.
+- Purpose: override labels and night/rest behavior for full parent vacations.
+
+Example:
+
+```json
+"vacation_metadata": {
+  "Nuit": {
+    "label": "N",
+    "is_night": true,
+    "requires_next_day_rest": true
+  }
+}
+```
+
+Notes:
+
+- `is_night` marks an assignment as a night assignment for night-specific safety rules.
+- `requires_next_day_rest` blocks non-night work on the following day.
+- Segment-level metadata in `half_vacations[].segments[]` overrides or inherits from the parent behavior.
 
 ### `holidays` (required)
 
@@ -108,6 +209,10 @@ Supported keys:
 - Using `YYYY-mm-dd` instead of `dd-mm-YYYY` in agent dates.
 - Adding comments inside JSON (JSON does not support comments).
 - Defining a shift in `vacations` without matching duration in `vacation_durations`.
+- Defining `half_vacations.CDP` (CDP is not splittable).
+- Defining half-vacation segment durations that do not sum to the parent duration.
+- Reusing a segment name that already exists as another vacation or segment.
+- Forgetting colors for newly added segments, making the planning harder to read.
 - Setting a negative staffing value (must be integer `>= 0`).
 - Forgetting required agent keys (all agent fields are expected, use empty arrays if needed).
 - Setting solver keys with wrong types (for example `"0.1"` as a string).

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -771,6 +771,7 @@ export default {
       }
 
       payload.half_vacations = this.buildHalfVacationsPayload(payload);
+      payload.vacation_colors = this.buildVacationColorsPayload(payload);
 
       payload.agents = (payload.agents || []).map((agent, index) => ({
         ...defaultAgent(`Agent${index + 1}`),
@@ -825,6 +826,21 @@ export default {
         };
       });
       return halfVacations;
+    },
+    buildVacationColorsPayload(payload) {
+      const allowedNames = new Set(payload.vacations || []);
+      Object.values(payload.half_vacations || {}).forEach((halfConfig) => {
+        (halfConfig.segments || []).forEach((segment) => {
+          allowedNames.add(segment.name);
+        });
+      });
+      const colors = {};
+      Object.entries(payload.vacation_colors || {}).forEach(([vacation, color]) => {
+        if (allowedNames.has(vacation) && /^#[0-9A-Fa-f]{6}$/.test(color)) {
+          colors[vacation] = color;
+        }
+      });
+      return colors;
     },
     formatValidationErrors(details) {
       if (!Array.isArray(details) || details.length === 0) {

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -183,5 +183,9 @@ describe('App.vue', () => {
       { name: 'Jour matin', duration: 6, label: 'J matin' },
       { name: 'Jour apres-midi', duration: 6, label: 'J aprem' },
     ]);
+    expect(payload.vacation_colors).toEqual({
+      'Jour matin': '#B9F6CA',
+      'Jour apres-midi': '#00C853',
+    });
   });
 });


### PR DESCRIPTION
## Objective

Consolidate the half-vacation configuration flow by documenting the full configuration contract and tightening frontend payload cleanup before saving interactive configuration changes.

## Breaking Change Notice

No API breaking change.

The frontend still saves the same backend configuration shape. The saved payload is now stricter about removing stale `vacation_colors` entries that no longer match active vacations or saved half-vacation segments.

## Scope

- Expand `docs/config-reference.md` with detailed half-vacation configuration guidance.
- Document segment-based coverage behavior:
  - full parent assignments cover every segment
  - segment assignments cover only their matching segment
  - `staffing_requirements[parent]` applies to every segment
- Document half-vacation validation rules:
  - `CDP` is not splittable
  - segment duration sum must match the parent duration
  - segment names must be unique
  - segment durations must be positive
  - half-vacations are not allowed on weekends or holidays
- Document `vacation_colors` for parent and segment display colors.
- Document `vacation_metadata`, including `is_night` and `requires_next_day_rest`.
- Add common configuration mistakes related to half-vacations.
- Clean frontend `vacation_colors` before saving so stale colors from removed or disabled segments are not persisted.
- Extend frontend tests to verify saved colors remain aligned with active vacations and saved half-vacation segments.

## Validation

- `npm test -- --runInBand` from `frontend/`
- `npm run lint` from `frontend/`
- `npm run build` from `frontend/`
- `backend/.venv/Scripts/python.exe -m pytest backend/tests -q`

## Results

- Frontend test suite passes: `11 passed`.
- Frontend lint passes with no errors.
- Frontend production build succeeds.
- Backend test suite passes: `117 passed`.

## Risks and Mitigations

- Risk: removing stale `vacation_colors` entries may surprise users who expected unused colors to remain in config.
- Mitigation: only colors for inactive vacations or unsaved/removed segments are removed; active parent and segment colors are preserved.

- Risk: documentation may diverge from backend validation over time.
- Mitigation: the documented rules mirror the current schema and runtime validation, including `CDP` rejection and segment duration checks.

- Risk: consolidation does not yet expose structured backend diagnostics in the frontend.
- Mitigation: this PR intentionally stays focused on config UX/docs cleanup; structured diagnostics remain the next functional item.