### PR TITLE
Soften minimum agent assignment rule

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -950,11 +950,6 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
         "detail": "Un agent aurait probablement besoin de couvrir plusieurs vacations le même jour.",
     },
     {
-        "constraint": "require_at_least_one_shift_per_agent",
-        "label": "au moins une vacation par agent",
-        "detail": "Tous les agents ne peuvent peut-être pas recevoir au moins une vacation sur la période.",
-    },
-    {
         "constraint": "cover_daily_shifts",
         "label": "couverture quotidienne des besoins",
         "detail": "Le nombre d'agents requis par date/vacation semble incompatible avec les disponibilités restantes.",

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -38,7 +38,6 @@ def register(registry: ConstraintRegistry) -> None:
     The hard constraints are:
     - Apply initial shifts
     - Limit one shift per day
-    - Require at least one shift per agent
     - Cover daily shifts
     - Avoid day after night
     - Limit CDP per week (historical hard business exception)
@@ -54,7 +53,6 @@ def register(registry: ConstraintRegistry) -> None:
     """
     registry.register_hard(apply_initial_shifts)
     registry.register_hard(limit_one_shift_per_day)
-    registry.register_hard(require_at_least_one_shift_per_agent)
     registry.register_hard(cover_daily_shifts)
     registry.register_hard(enforce_full_weekend_composition)
     registry.register_hard(enforce_min_free_weekends_per_horizon)
@@ -115,29 +113,6 @@ def limit_one_shift_per_day(ctx: SolverContext) -> None:
                 sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations)
                 <= 1
             )
-
-
-def require_at_least_one_shift_per_agent(ctx: SolverContext) -> None:
-    """
-    Requires each agent to have at least one shift per week.
-
-    This constraint is applied per agent and ensures that the sum of all shift variables
-    for that agent on all days in the week's schedule is greater than or equal to one.
-    This prevents the agent from being assigned no shifts at all.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    for agent in ctx.agents:
-        agent_name = agent["name"]
-        ctx.model.Add(
-            sum(
-                ctx.planning[(agent_name, day, vacation)]
-                for day in ctx.week_schedule
-                for vacation in ctx.assignable_vacations
-            )
-            >= 1
-        )
 
 
 def cover_daily_shifts(ctx: SolverContext) -> None:

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -58,6 +58,20 @@ def apply_objective(ctx: SolverContext) -> None:
         )
     )
 
+    agent_usage_bonus_weight = 5
+    agent_usage_bonus_terms = []
+    for agent in ctx.agents:
+        agent_name = agent["name"]
+        is_used = ctx.model.NewBoolVar(f"{agent_name}_used_at_least_once")
+        worked_assignments = [
+            ctx.planning[(agent_name, day, vacation)]
+            for day in ctx.week_schedule
+            for vacation in ctx.assignable_vacations
+        ]
+        ctx.model.Add(sum(worked_assignments) >= 1).OnlyEnforceIf(is_used)
+        ctx.model.Add(sum(worked_assignments) == 0).OnlyEnforceIf(is_used.Not())
+        agent_usage_bonus_terms.append(is_used * agent_usage_bonus_weight)
+
     preserve_existing_weight = 10000
     change_existing_full_penalty = 1000
     change_existing_half_penalty = 2000
@@ -87,6 +101,7 @@ def apply_objective(ctx: SolverContext) -> None:
         objective_preferred_vacations
         + objective_other_vacations
         + penalized_vacations
+        + cp_model.LinearExpr.Sum(agent_usage_bonus_terms)
         + cp_model.LinearExpr.Sum(preserve_existing_assignments)
         - half_vacation_penalties
         - cp_model.LinearExpr.Sum(change_existing_assignments)

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -597,6 +597,72 @@ def test_generate_planning_paid_leave_hours_balancing_regression():
     assert "info" not in result
 
 
+def test_generate_planning_allows_agent_with_full_period_leave_to_have_no_shift():
+    """
+    Agents fully blocked by leave should not make the model infeasible merely
+    because they receive no worked assignment on the generated period.
+    """
+
+    agents = [
+        {
+            "name": "Agent1",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [{"start": "05-01-2026", "end": "09-01-2026"}],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Agent2",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+    ]
+    vacations = ["Jour"]
+    week_schedule = [
+        "Lun. 05-01",
+        "Mar. 06-01",
+        "Mer. 07-01",
+        "Jeu. 08-01",
+        "Ven. 09-01",
+    ]
+
+    result = generate_planning(
+        agents,
+        vacations,
+        week_schedule,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={},
+        planning_start_date="2026-01-05",
+        runtime_config={
+            "vacation_durations": {"Jour": 12, "Conge": 7},
+            "staffing_requirements": {"Jour": 1},
+            "holidays": [],
+            "solver": {
+                "max_time_seconds": 30,
+                "relative_gap_limit": 0.1,
+                "num_search_workers": 0,
+                "global_max_gap": 600,
+                "period_max_gap": 600,
+                "max_weekly_hours": 60,
+                "optimize_period_balance": False,
+                "period_balance_weight": 2,
+                "min_free_weekends_per_horizon": 0,
+            },
+        },
+    )
+
+    assert "info" not in result
+    assert result["Agent1"] == []
+    assert len(result["Agent2"]) == len(week_schedule)
+
+
 def test_generate_planning_ignores_leave_periods_from_other_years():
     """
     Regression test: leave periods from another year must not block a target planning year.

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -4,6 +4,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 from app import (
+    RELAXED_CONSTRAINT_DIAGNOSTICS,
     _diagnose_manual_entry_conflicts,
     _probe_relaxed_hard_constraints,
     _inject_manual_status_entries,
@@ -522,6 +523,12 @@ def test_probe_relaxed_hard_constraints_reports_feasible_relaxed_constraint():
 
     assert reasons[0]["code"] == "RELAXED_CONSTRAINT_MAKES_FEASIBLE"
     assert "couverture quotidienne" in reasons[0]["message"]
+
+
+def test_relaxed_constraints_do_not_include_agent_minimum_assignment():
+    constraints = [diagnostic["constraint"] for diagnostic in RELAXED_CONSTRAINT_DIAGNOSTICS]
+
+    assert "require_at_least_one_shift_per_agent" not in constraints
 
 
 def test_probe_relaxed_hard_constraints_uses_generic_rest_wording():


### PR DESCRIPTION
## Objective

Replace the historical hard constraint requiring every agent to receive at least one worked assignment with a soft objective bonus, so agents fully unavailable or on leave for a generated period no longer make the model infeasible.

## Breaking Change Notice

No API breaking change.

Solver behavior changes: an agent may now have zero worked assignments on a generated period when constraints make that appropriate. The solver still mildly prefers using each agent at least once through a small objective bonus.

## Scope

- Remove `require_at_least_one_shift_per_agent` from hard solver constraints.
- Remove the corresponding hard-constraint function.
- Add a weak objective bonus when an agent receives at least one worked assignment.
- Remove the obsolete hard constraint from relaxed-constraint diagnostics.
- Add regression coverage for an agent fully on leave during the generated period.
- Add diagnostic coverage to ensure the removed hard constraint no longer appears in relaxation probes.

## Validation

- `backend/.venv/Scripts/python.exe -m pytest backend/tests -q`
- `npm test -- --runInBand` from `frontend/`
- `npm run lint` from `frontend/`
- `npm run build` from `frontend/`

## Results

- Backend test suite passes: `119 passed`.
- Frontend test suite passes: `12 passed`.
- Frontend lint passes with no errors.
- Frontend production build succeeds.

## Risks and Mitigations

- Risk: a technically available agent may occasionally receive no worked assignment.
- Mitigation: the objective now includes a small usage bonus, while workload balancing remains driven by hour-based constraints and objectives.

- Risk: removing the hard constraint may change schedules that previously forced every agent onto the period.
- Mitigation: this aligns with the current hour-volume model and avoids infeasibility for agents fully unavailable or on leave.

- Risk: the bonus weight could need tuning.
- Mitigation: it is intentionally weak (`5`) so it does not overpower preferences, avoid penalties, half-vacation penalties, or existing-assignment preservation.