### PR TITLE
Half vacation docs finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable half-vacation support with assignable split segments, segment labels, colors, soft penalties, and night/rest metadata.
+- Added segment-based coverage so parent shifts can be covered by full assignments or matching half-vacation segments.
+- Added structured backend diagnostics for existing-schedule optimization, including segment-level blockers, suggested actions, and sample blocked agents.
+- Added frontend display for assignment labels, modified existing assignments, and structured optimization diagnostics.
+- Added frontend half-vacation configuration editing for segments, penalties, colors, night flags, and next-day rest flags.
+
+### Changed
+
+- Changed existing-schedule optimization so existing assignments are preserved through objective weighting instead of being treated as hard locks.
+- Changed the historical minimum-assignment rule from a hard constraint to a weak objective bonus, allowing fully unavailable or on-leave agents to receive zero worked assignments.
+- Updated planning totals so `Total affectations` counts worked assignments only while `Total Heures` uses actual assignment durations.
+- Expanded configuration documentation for `half_vacations`, `vacation_colors`, and `vacation_metadata`.
+
+### Fixed
+
+- Prevented `CDP` from being configured as a split half-vacation.
+- Removed stale segment colors from frontend configuration payloads before saving.
+- Removed obsolete relaxed diagnostics for the former hard minimum-assignment rule.
+
 ## [0.9.3] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@
 - 🔨 Flexible parameters defined through the `config.json` file.
 - ✉️ Support for agent preferences, exclusions, training days, and **multiple leave periods**.
 - 🧩 Dynamic shift types and simultaneous staffing quotas per shift (`staffing_requirements`).
+- Split-shift support through configurable `half_vacations`, including half-day/half-night segments, labels, colors, penalties, and night/rest metadata.
 
 ### 🔧 Visual Interactivity
 
 - 🔍 Vue.js-powered frontend for seamless schedule visualization and interaction.
 - ⚙️ Built-in interactive configuration mode (load active/default config, edit, save, and generate without backend restart).
+- Existing-schedule optimization mode with structured blocking diagnostics and modified-assignment reporting.
 
 ---
 
@@ -154,10 +156,21 @@ Core sections in `config.json`:
 - `vacations`: generated shift types (dynamic names supported)
 - `staffing_requirements`: simultaneous required agents per shift (`>= 0`, fallback `1`)
 - `vacation_durations`: paid-hour durations for each configured shift plus `Conge`
+- `half_vacations`: optional split segments for parent shifts such as `Jour` or `Nuit`
+- `vacation_colors`: frontend display colors for full shifts and half-vacation segments
+- `vacation_metadata`: optional labels and night/rest behavior for parent shifts
 - `holidays`: recurring public holidays
 - `solver`: optional runtime and fairness tuning
   - `max_weekly_hours`: strict weekly worked-hours cap per agent, default `36`
   - `global_max_gap` / `period_max_gap`: paid-hour balance gaps between agents, expressed in tenths of hours
+
+Half-vacation notes:
+
+- Parent shifts remain assignable as full shifts.
+- Enabled half-vacation segments can cover parent shift requirements segment by segment.
+- `CDP` is intentionally not splittable.
+- Half-vacations are rejected on weekends and recurring holidays.
+- See `docs/config-reference.md` for full examples and validation rules.
 
 ---
 

--- a/docs/optimization-existing-schedule-mvp.md
+++ b/docs/optimization-existing-schedule-mvp.md
@@ -1,5 +1,16 @@
 # Optimization of Existing Schedule — MVP Technical Spec
 
+## Status Note
+
+This document describes the original MVP target. The implemented feature has since evolved:
+
+- manual shift entries are now treated as existing assignments to preserve when possible, not hard locks;
+- status entries still inject hard non-working constraints;
+- backend responses include structured blocking reasons, segment-level diagnostics, impacted cells, suggestions, and modified existing assignments;
+- the frontend displays warnings, suggestions, blocking reasons, structured diagnostic segments, and existing assignments modified by the optimizer.
+
+Use this document as historical implementation context. For current API/config behavior, also see `docs/config-reference.md` and the route tests in `backend/tests/test_routes.py`.
+
 ## 1) Goal
 
 Add a third planning mode that lets users:


### PR DESCRIPTION
## Summary

Finalizes the documentation pass for the half-vacation feature set before merging into `half-day-half-night`.

This PR updates the README, changelog, and historical existing-schedule optimization MVP document so the delivered backend, frontend, and configuration scope is clearly documented.

## Changes

- Added half-vacations to the main README feature list.
- Documented existing-schedule optimization with structured diagnostics and modified-assignment reporting.
- Added `half_vacations`, `vacation_colors`, and `vacation_metadata` to the README configuration summary.
- Documented the main business rules:
  - parent shifts remain assignable;
  - segment-based coverage is supported;
  - `CDP` cannot be split;
  - half-vacations are forbidden on weekends and public holidays.
- Added a complete `Unreleased` changelog entry for the half-vacation feature set.
- Added a status note to the existing-schedule optimization MVP spec to clarify that the document is now historical.

## Validation

- `git diff --check`

## Notes

This PR is intentionally documentation-only and should be merged into `half-day-half-night` before opening the final PR for that branch.