### PR TITLE
Add half-day and half-night scheduling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable half-vacation support with assignable split segments, segment labels, colors, soft penalties, and night/rest metadata.
+- Added segment-based coverage so parent shifts can be covered by full assignments or matching half-vacation segments.
+- Added structured backend diagnostics for existing-schedule optimization, including segment-level blockers, suggested actions, and sample blocked agents.
+- Added frontend display for assignment labels, modified existing assignments, and structured optimization diagnostics.
+- Added frontend half-vacation configuration editing for segments, penalties, colors, night flags, and next-day rest flags.
+
+### Changed
+
+- Changed existing-schedule optimization so existing assignments are preserved through objective weighting instead of being treated as hard locks.
+- Changed the historical minimum-assignment rule from a hard constraint to a weak objective bonus, allowing fully unavailable or on-leave agents to receive zero worked assignments.
+- Updated planning totals so `Total affectations` counts worked assignments only while `Total Heures` uses actual assignment durations.
+- Expanded configuration documentation for `half_vacations`, `vacation_colors`, and `vacation_metadata`.
+
+### Fixed
+
+- Prevented `CDP` from being configured as a split half-vacation.
+- Removed stale segment colors from frontend configuration payloads before saving.
+- Removed obsolete relaxed diagnostics for the former hard minimum-assignment rule.
+
 ## [0.9.3] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@
 - 🔨 Flexible parameters defined through the `config.json` file.
 - ✉️ Support for agent preferences, exclusions, training days, and **multiple leave periods**.
 - 🧩 Dynamic shift types and simultaneous staffing quotas per shift (`staffing_requirements`).
+- Split-shift support through configurable `half_vacations`, including half-day/half-night segments, labels, colors, penalties, and night/rest metadata.
 
 ### 🔧 Visual Interactivity
 
 - 🔍 Vue.js-powered frontend for seamless schedule visualization and interaction.
 - ⚙️ Built-in interactive configuration mode (load active/default config, edit, save, and generate without backend restart).
+- Existing-schedule optimization mode with structured blocking diagnostics and modified-assignment reporting.
 
 ---
 
@@ -154,10 +156,21 @@ Core sections in `config.json`:
 - `vacations`: generated shift types (dynamic names supported)
 - `staffing_requirements`: simultaneous required agents per shift (`>= 0`, fallback `1`)
 - `vacation_durations`: paid-hour durations for each configured shift plus `Conge`
+- `half_vacations`: optional split segments for parent shifts such as `Jour` or `Nuit`
+- `vacation_colors`: frontend display colors for full shifts and half-vacation segments
+- `vacation_metadata`: optional labels and night/rest behavior for parent shifts
 - `holidays`: recurring public holidays
 - `solver`: optional runtime and fairness tuning
   - `max_weekly_hours`: strict weekly worked-hours cap per agent, default `36`
   - `global_max_gap` / `period_max_gap`: paid-hour balance gaps between agents, expressed in tenths of hours
+
+Half-vacation notes:
+
+- Parent shifts remain assignable as full shifts.
+- Enabled half-vacation segments can cover parent shift requirements segment by segment.
+- `CDP` is intentionally not splittable.
+- Half-vacations are rejected on weekends and recurring holidays.
+- See `docs/config-reference.md` for full examples and validation rules.
 
 ---
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from jsonschema import Draft202012Validator
+from solver.catalog import build_vacation_catalog, is_night_assignment, requires_next_day_rest
 from solver.engine import generate_planning as generate_planning_engine
 
 app = Flask(__name__)
@@ -59,6 +60,23 @@ def validate_runtime_config(candidate_config):
                         "message": (
                             f"Missing duration for configured vacation '{vacation}'."
                         ),
+                    }
+                )
+
+    if not errors:
+        try:
+            build_vacation_catalog(candidate_config)
+        except ValueError as exc:
+            errors.append({"path": "half_vacations", "message": str(exc)})
+
+    half_vacations = candidate_config.get("half_vacations", {})
+    if isinstance(vacations, list) and isinstance(half_vacations, dict):
+        for parent in half_vacations:
+            if parent not in vacations:
+                errors.append(
+                    {
+                        "path": f"half_vacations/{parent}",
+                        "message": f"Unknown parent vacation '{parent}'.",
                     }
                 )
 
@@ -148,7 +166,11 @@ def _build_planning_payload(payload, runtime_config):
     # Retrieving data from the JSON file
     agents = runtime_config["agents"]
     vacations = runtime_config["vacations"]
-    vacation_durations = runtime_config["vacation_durations"]
+    catalog = build_vacation_catalog(runtime_config)
+    assignable_vacations = catalog["assignable_vacations"]
+    vacation_durations = dict(runtime_config["vacation_durations"])
+    for assignment, metadata in catalog["assignment_metadata"].items():
+        vacation_durations[assignment] = metadata.duration / 10
     holidays = runtime_config["holidays"]
     unavailable = {}
     dayOff = {}
@@ -188,7 +210,7 @@ def _build_planning_payload(payload, runtime_config):
 
     # Validate initial shifts
     valid_agents = [agent["name"] for agent in agents]
-    valid_vacations = vacations
+    valid_vacations = assignable_vacations
     for agent_name, shifts in initial_shifts.items():
         if not isinstance(shifts, list):
             return {"error": f"initial_shifts for {agent_name} must be a list"}, 400
@@ -267,6 +289,8 @@ def _build_planning_payload(payload, runtime_config):
     return {
         "planning": full_planning,
         "vacation_durations": vacation_durations,
+        "vacation_colors": runtime_config.get("vacation_colors", {}),
+        "assignable_vacations": assignable_vacations,
         "week_schedule": original_week_schedule,
         "holidays": holidays,
         "unavailable": unavailable,
@@ -334,7 +358,7 @@ def _parse_manual_entries(manual_entries, runtime_config, start_date, end_date):
         return None, None, None, (jsonify({"error": "manual_entries must be a list"}), 400)
 
     valid_agents = {agent["name"] for agent in runtime_config["agents"]}
-    valid_vacations = set(runtime_config["vacations"])
+    valid_vacations = set(build_vacation_catalog(runtime_config)["assignable_vacations"])
     valid_restriction_types = set(
         (runtime_config.get("restriction_types_durations") or {}).keys()
     )
@@ -544,7 +568,7 @@ def _build_manual_shift_indexes(manual_entries):
     return manual_shifts_by_agent_day, manual_counts_by_day_shift, dates_to_check
 
 
-def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day):
+def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config):
     agent_name = agent["name"]
     locked_shifts = manual_shifts_by_agent_day.get((agent_name, iso_date), [])
     if locked_shifts:
@@ -552,16 +576,19 @@ def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day
 
     if _agent_has_status_on_day(agent, iso_date):
         return False
-    if vacation in (agent.get("restriction") or []):
+    restricted = set(agent.get("restriction") or [])
+    if vacation in restricted:
+        return False
+    catalog = build_vacation_catalog(runtime_config)
+    metadata = catalog["assignment_metadata"].get(vacation)
+    if metadata and metadata.parent in restricted:
         return False
     return True
-
 
 def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_config):
     reasons = []
     by_agent = {agent["name"]: agent for agent in runtime_config.get("agents", [])}
     details_by_code = {
-        "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED": [],
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": [],
         "MANUAL_SHIFT_AFTER_NIGHT": [],
         "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": [],
@@ -569,22 +596,17 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
         "MANUAL_FULL_WEEKEND_COMPOSITION_CONFLICT": [],
     }
     counts_by_code = {code: 0 for code in details_by_code}
+    catalog = build_vacation_catalog(runtime_config)
 
     weekly_counts = {}
     for (agent_name, iso_date), shifts in manual_shifts_by_agent_day.items():
         if agent_name not in by_agent or not is_valid_date(iso_date):
             continue
         week_key = (agent_name, datetime.strptime(iso_date, "%Y-%m-%d").isocalendar()[:2])
-        weekly_counts.setdefault(week_key, {"Jour": 0, "CDP": 0})
-        weekly_counts[week_key]["Jour"] += shifts.count("Jour")
+        weekly_counts.setdefault(week_key, {"CDP": 0})
         weekly_counts[week_key]["CDP"] += shifts.count("CDP")
 
     for (agent_name, week), counts in weekly_counts.items():
-        if counts["Jour"] > 3:
-            counts_by_code["MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"] += 1
-            details_by_code["MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"].append(
-                f"{agent_name} / semaine {week[1]}: {counts['Jour']} vacations Jour manuelles pour 3 maximum"
-            )
         if counts["CDP"] > 2:
             counts_by_code["MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED"] += 1
             details_by_code["MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED"].append(
@@ -600,17 +622,21 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
         next_iso = (day_dt + timedelta(days=1)).strftime("%Y-%m-%d")
         next_day_str = (day_dt + timedelta(days=1)).strftime("%d-%m-%Y")
 
-        if "Nuit" in shifts:
+        rest_triggering_shifts = [
+            shift for shift in shifts if requires_next_day_rest(catalog, shift)
+        ]
+        if rest_triggering_shifts:
             next_manual_shifts = manual_shifts_by_agent_day.get((agent_name, next_iso), [])
             if next_manual_shifts:
                 counts_by_code["MANUAL_SHIFT_AFTER_NIGHT"] += 1
                 details_by_code["MANUAL_SHIFT_AFTER_NIGHT"].append(
-                    f"{agent_name} / {iso_date}: Nuit suivie de {', '.join(next_manual_shifts)} le {next_iso}"
+                    f"{agent_name} / {iso_date}: {', '.join(rest_triggering_shifts)} "
+                    f"suivie de {', '.join(next_manual_shifts)} le {next_iso}"
                 )
             if next_day_str in (agent.get("unavailable") or []) or next_day_str in (agent.get("training") or []):
                 counts_by_code["MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING"] += 1
                 details_by_code["MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING"].append(
-                    f"{agent_name} / {iso_date}: Nuit avant indisponibilité ou formation le {next_iso}"
+                    f"{agent_name} / {iso_date}: affectation de nuit avant indisponibilité ou formation le {next_iso}"
                 )
 
         if day_dt.weekday() == 5 and _agent_has_status_on_day(agent, next_iso):
@@ -628,7 +654,11 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
             previous_shifts = manual_shifts_by_agent_day.get((agent_name, previous_iso), [])
             next_shifts = manual_shifts_by_agent_day.get((agent_name, next_iso), [])
             forbidden_previous = [shift for shift in previous_shifts if shift != "CDP"]
-            forbidden_next = [shift for shift in next_shifts if shift not in {"CDP", "Nuit"}]
+            forbidden_next = [
+                shift
+                for shift in next_shifts
+                if shift != "CDP" and not is_night_assignment(catalog, shift)
+            ]
             if forbidden_previous or forbidden_next:
                 counts_by_code["MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED"] += 1
                 details_by_code["MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED"].append(
@@ -636,7 +666,6 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
                 )
 
     reason_messages = {
-        "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED": "La limite de 3 vacations Jour par semaine est dépassée par des saisies manuelles.",
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": "La limite de 2 vacations CDP par semaine est dépassée par des saisies manuelles.",
         "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle est posée le lendemain d'une Nuit manuelle.",
         "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": "Une Nuit manuelle est posée avant une indisponibilité ou une formation.",
@@ -662,9 +691,9 @@ def _diagnose_staffing_capacity_conflicts(
 ):
     reasons = []
     agents = runtime_config.get("agents", [])
-    vacations = runtime_config.get("vacations", [])
     staffing_requirements = runtime_config.get("staffing_requirements", {})
     holidays = set(runtime_config.get("holidays", []))
+    catalog = build_vacation_catalog(runtime_config)
 
     understaffed_shift_days = 0
     overstaffed_manual_shift_days = 0
@@ -675,37 +704,55 @@ def _diagnose_staffing_capacity_conflicts(
         day_dt = datetime.strptime(iso_date, "%Y-%m-%d")
         day_token = day_dt.strftime("%d-%m")
         is_weekend = day_dt.weekday() >= 5
-        for vacation in vacations:
+        for vacation in catalog["coverage_vacations"]:
             required_agents = staffing_requirements.get(vacation, 1)
             if vacation == "CDP" and (is_weekend or day_token in holidays):
                 required_agents = 0
 
-            manual_count = manual_counts_by_day_shift.get((iso_date, vacation), 0)
-            if manual_count > required_agents:
-                overstaffed_manual_shift_days += 1
-                overstaffed_details.append(
-                    f"{iso_date} / {vacation}: {manual_count} manuel(s) pour {required_agents} requis"
+            for segment in catalog["coverage_segments"].get(vacation, [vacation]):
+                covering_assignments = catalog["segment_covering_assignments"].get(
+                    (vacation, segment), [vacation]
                 )
-                continue
+                manual_count = sum(
+                    manual_counts_by_day_shift.get((iso_date, assignment), 0)
+                    for assignment in covering_assignments
+                )
+                if manual_count > required_agents:
+                    overstaffed_manual_shift_days += 1
+                    overstaffed_details.append(
+                        f"{iso_date} / {vacation} / {segment}: "
+                        f"{manual_count} manuel(s) pour {required_agents} requis"
+                    )
+                    continue
 
-            eligible_count = sum(
-                1
-                for agent in agents
-                if _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day)
-            )
-            if eligible_count < required_agents:
-                understaffed_shift_days += 1
-                understaffed_details.append(
-                    f"{iso_date} / {vacation}: {eligible_count} agent(s) possible(s) pour {required_agents} requis"
+                eligible_count = sum(
+                    1
+                    for agent in agents
+                    if any(
+                        _agent_can_cover_shift(
+                            agent,
+                            iso_date,
+                            assignment,
+                            manual_shifts_by_agent_day,
+                            runtime_config,
+                        )
+                        for assignment in covering_assignments
+                    )
                 )
+                if eligible_count < required_agents:
+                    understaffed_shift_days += 1
+                    understaffed_details.append(
+                        f"{iso_date} / {vacation} / {segment}: "
+                        f"{eligible_count} agent(s) possible(s) pour {required_agents} requis"
+                    )
 
     if overstaffed_manual_shift_days:
         reasons.append(
             {
                 "code": "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT",
                 "message": (
-                    "Trop de vacations manuelles sont posées sur au moins un couple "
-                    "date/vacation par rapport au besoin configuré."
+                    "Trop d'affectations manuelles sont posées sur au moins un "
+                    "segment par rapport au besoin configuré."
                 ),
                 "count": overstaffed_manual_shift_days,
                 "details": overstaffed_details[:5],
@@ -716,8 +763,8 @@ def _diagnose_staffing_capacity_conflicts(
             {
                 "code": "STAFFING_REQUIREMENT_UNMET",
                 "message": (
-                    "Le besoin de couverture ne peut pas être atteint pour au moins une "
-                    "date/vacation avec les agents encore disponibles."
+                    "Le besoin de couverture ne peut pas être atteint pour au moins "
+                    "un segment avec les agents encore disponibles."
                 ),
                 "count": understaffed_shift_days,
                 "details": understaffed_details[:5],
@@ -777,11 +824,6 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
         "constraint": "block_leave_and_compute_paid_hours",
         "label": "congés",
         "detail": "Relâcher les congés rendrait le planning faisable, ce qui indique un manque de capacité disponible.",
-    },
-    {
-        "constraint": "limit_day_shifts_per_week",
-        "label": "limite de 3 vacations Jour par semaine",
-        "detail": "La limite hebdomadaire des vacations Jour semble trop contraignante pour couvrir la période.",
     },
     {
         "constraint": "block_night_before_unavailable",
@@ -962,8 +1004,14 @@ def compute_previous_week_schedule():
     start_date = payload["start_date"]
     previous_week_schedule = get_previous_week_schedule(start_date)
 
-    agents = get_active_config()["agents"]
-    return jsonify({"previous_week_schedule": previous_week_schedule, "agents": agents})
+    runtime_config = get_active_config()
+    agents = runtime_config["agents"]
+    assignable_vacations = build_vacation_catalog(runtime_config)["assignable_vacations"]
+    return jsonify({
+        "previous_week_schedule": previous_week_schedule,
+        "agents": agents,
+        "assignable_vacations": assignable_vacations,
+    })
 
 
 @app.route("/optimize-existing-planning", methods=["POST"])

--- a/backend/app.py
+++ b/backend/app.py
@@ -653,22 +653,52 @@ def _build_manual_shift_indexes(manual_entries):
     return manual_shifts_by_agent_day, manual_counts_by_day_shift, dates_to_check
 
 
-def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config):
+def _agent_cover_blockers(agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config, catalog):
+    blockers = []
     agent_name = agent["name"]
     locked_shifts = manual_shifts_by_agent_day.get((agent_name, iso_date), [])
-    if locked_shifts:
-        return vacation in locked_shifts
+    if locked_shifts and vacation not in locked_shifts:
+        blockers.append("existing_assignment")
 
     if _agent_has_status_on_day(agent, iso_date):
-        return False
+        blockers.append("status")
     restricted = set(agent.get("restriction") or [])
     if vacation in restricted:
-        return False
-    catalog = build_vacation_catalog(runtime_config)
+        blockers.append("restriction")
     metadata = catalog["assignment_metadata"].get(vacation)
     if metadata and metadata.parent in restricted:
-        return False
-    return True
+        blockers.append("parent_restriction")
+    if metadata and metadata.is_half and is_valid_date(iso_date):
+        day_dt = datetime.strptime(iso_date, "%Y-%m-%d")
+        day_token = day_dt.strftime("%d-%m")
+        if day_dt.weekday() >= 5:
+            blockers.append("half_weekend")
+        if day_token in set(runtime_config.get("holidays", [])):
+            blockers.append("half_holiday")
+    return blockers
+
+
+def _agent_can_cover_shift(agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config):
+    catalog = build_vacation_catalog(runtime_config)
+    return not _agent_cover_blockers(
+        agent, iso_date, vacation, manual_shifts_by_agent_day, runtime_config, catalog
+    )
+
+
+def _format_blocker_summary(blocker_counts):
+    labels = {
+        "existing_assignment": "affectation existante différente",
+        "status": "statut bloquant",
+        "restriction": "restriction directe",
+        "parent_restriction": "restriction parent",
+        "half_weekend": "demi-vacation interdite week-end",
+        "half_holiday": "demi-vacation interdite jour férié",
+    }
+    return [
+        f"{labels.get(code, code)}: {count}"
+        for code, count in sorted(blocker_counts.items())
+        if count
+    ]
 
 def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_config):
     reasons = []
@@ -752,8 +782,8 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
 
     reason_messages = {
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": "La limite de 2 vacations CDP par semaine est dépassée par des saisies manuelles.",
-        "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle est posée le lendemain d'une Nuit manuelle.",
-        "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": "Une Nuit manuelle est posée avant une indisponibilité ou une formation.",
+        "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle est posée le lendemain d'une affectation nécessitant un repos.",
+        "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": "Une affectation nécessitant un repos est posée avant une indisponibilité ou une formation.",
         "MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED": "Une vacation manuelle ne respecte pas les règles de veille/lendemain de formation.",
         "MANUAL_FULL_WEEKEND_COMPOSITION_CONFLICT": "Une saisie manuelle empêche de respecter la règle de week-end complet.",
     }
@@ -784,6 +814,8 @@ def _diagnose_staffing_capacity_conflicts(
     overstaffed_manual_shift_days = 0
     understaffed_details = []
     overstaffed_details = []
+    understaffed_segments = []
+    overstaffed_segments = []
 
     for iso_date in sorted(dates_to_check):
         day_dt = datetime.strptime(iso_date, "%Y-%m-%d")
@@ -808,27 +840,77 @@ def _diagnose_staffing_capacity_conflicts(
                         f"{iso_date} / {vacation} / {segment}: "
                         f"{manual_count} manuel(s) pour {required_agents} requis"
                     )
+                    overstaffed_segments.append(
+                        {
+                            "date": iso_date,
+                            "vacation": vacation,
+                            "segment": segment,
+                            "required_agents": required_agents,
+                            "manual_count": manual_count,
+                            "actions": ["clear_cell", "reduce_existing_assignment_count"],
+                        }
+                    )
                     continue
 
-                eligible_count = sum(
-                    1
-                    for agent in agents
-                    if any(
-                        _agent_can_cover_shift(
+                eligible_count = 0
+                blocker_counts = {}
+                sample_blocked_agents = []
+                for agent in agents:
+                    assignment_blockers = [
+                        _agent_cover_blockers(
                             agent,
                             iso_date,
                             assignment,
                             manual_shifts_by_agent_day,
                             runtime_config,
+                            catalog,
                         )
                         for assignment in covering_assignments
+                    ]
+                    if any(not blockers for blockers in assignment_blockers):
+                        eligible_count += 1
+                        continue
+                    flattened_blockers = sorted(
+                        {blocker for blockers in assignment_blockers for blocker in blockers}
                     )
-                )
+                    for blocker in flattened_blockers:
+                        blocker_counts[blocker] = blocker_counts.get(blocker, 0) + 1
+                    if len(sample_blocked_agents) < 5:
+                        sample_blocked_agents.append(
+                            {
+                                "agent": agent.get("name"),
+                                "reasons": flattened_blockers,
+                            }
+                        )
                 if eligible_count < required_agents:
                     understaffed_shift_days += 1
+                    blocker_summary = _format_blocker_summary(blocker_counts)
+                    actions = [
+                        "free_agent",
+                        "increase_max_weekly_hours",
+                        "reduce_staffing_requirement",
+                    ]
+                    if is_weekend or day_token in holidays:
+                        actions.append("use_full_vacation")
+                    else:
+                        actions.append("allow_or_assign_half_vacations")
                     understaffed_details.append(
                         f"{iso_date} / {vacation} / {segment}: "
-                        f"{eligible_count} agent(s) possible(s) pour {required_agents} requis"
+                        f"{eligible_count} agent(s) possible(s) pour {required_agents} requis. "
+                        f"Blocages: {', '.join(blocker_summary) if blocker_summary else 'non identifiés'}. "
+                        f"Actions possibles: {', '.join(actions)}."
+                    )
+                    understaffed_segments.append(
+                        {
+                            "date": iso_date,
+                            "vacation": vacation,
+                            "segment": segment,
+                            "required_agents": required_agents,
+                            "eligible_agents": eligible_count,
+                            "blockers": blocker_counts,
+                            "sample_blocked_agents": sample_blocked_agents,
+                            "actions": actions,
+                        }
                     )
 
     if overstaffed_manual_shift_days:
@@ -841,6 +923,7 @@ def _diagnose_staffing_capacity_conflicts(
                 ),
                 "count": overstaffed_manual_shift_days,
                 "details": overstaffed_details[:5],
+                "segments": overstaffed_segments[:5],
             }
         )
     if understaffed_shift_days:
@@ -853,6 +936,7 @@ def _diagnose_staffing_capacity_conflicts(
                 ),
                 "count": understaffed_shift_days,
                 "details": understaffed_details[:5],
+                "segments": understaffed_segments[:5],
             }
         )
 
@@ -887,8 +971,8 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
     },
     {
         "constraint": "avoid_day_after_night",
-        "label": "repos après une Nuit",
-        "detail": "Une affectation le lendemain d'une Nuit semble nécessaire pour trouver une solution.",
+        "label": "repos après affectation de nuit",
+        "detail": "Une affectation le lendemain d'une vacation nécessitant un repos semble nécessaire pour trouver une solution.",
     },
     {
         "constraint": "limit_cdp_per_week",
@@ -912,13 +996,13 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
     },
     {
         "constraint": "block_night_before_unavailable",
-        "label": "Nuit avant indisponibilité",
-        "detail": "Une Nuit avant une indisponibilité semble nécessaire pour trouver une solution.",
+        "label": "affectation repos avant indisponibilité",
+        "detail": "Une affectation nécessitant un repos avant une indisponibilité semble nécessaire pour trouver une solution.",
     },
     {
         "constraint": "block_night_before_training",
-        "label": "Nuit avant formation",
-        "detail": "Une Nuit avant une formation semble nécessaire pour trouver une solution.",
+        "label": "affectation repos avant formation",
+        "detail": "Une affectation nécessitant un repos avant une formation semble nécessaire pour trouver une solution.",
     },
     {
         "constraint": "limit_pre_post_training",
@@ -932,8 +1016,8 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
     },
     {
         "constraint": "block_monday_night_after_weekend_nights",
-        "label": "Nuit du lundi après nuits de week-end",
-        "detail": "La règle de Nuit du lundi après nuits de week-end semble bloquer une solution.",
+        "label": "affectation de nuit du lundi après week-end",
+        "detail": "La règle d'affectation de nuit du lundi après des affectations de nuit de week-end semble bloquer une solution.",
     },
     {
         "constraint": "apply_agent_restrictions",

--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,13 @@ def validate_runtime_config(candidate_config):
                         "message": f"Unknown parent vacation '{parent}'.",
                     }
                 )
+            elif parent == "CDP":
+                errors.append(
+                    {
+                        "path": "half_vacations/CDP",
+                        "message": "CDP ne peut pas être découpé en demi-vacations.",
+                    }
+                )
 
     return errors
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -950,11 +950,6 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
         "detail": "Un agent aurait probablement besoin de couvrir plusieurs vacations le même jour.",
     },
     {
-        "constraint": "require_at_least_one_shift_per_agent",
-        "label": "au moins une vacation par agent",
-        "detail": "Tous les agents ne peuvent peut-être pas recevoir au moins une vacation sur la période.",
-    },
-    {
         "constraint": "cover_daily_shifts",
         "label": "couverture quotidienne des besoins",
         "detail": "Le nombre d'agents requis par date/vacation semble incompatible avec les disponibilités restantes.",

--- a/backend/app.py
+++ b/backend/app.py
@@ -175,6 +175,10 @@ def _build_planning_payload(payload, runtime_config):
     vacations = runtime_config["vacations"]
     catalog = build_vacation_catalog(runtime_config)
     assignable_vacations = catalog["assignable_vacations"]
+    assignment_labels = {
+        assignment: metadata.label or assignment
+        for assignment, metadata in catalog["assignment_metadata"].items()
+    }
     vacation_durations = dict(runtime_config["vacation_durations"])
     for assignment, metadata in catalog["assignment_metadata"].items():
         vacation_durations[assignment] = metadata.duration / 10
@@ -214,6 +218,9 @@ def _build_planning_payload(payload, runtime_config):
     initial_shifts = payload.get("initial_shifts", {})
     if not isinstance(initial_shifts, dict):
         return {"error": "initial_shifts must be an object"}, 400
+    existing_assignments = payload.get("existing_assignments", {})
+    if not isinstance(existing_assignments, dict):
+        return {"error": "existing_assignments must be an object"}, 400
 
     # Validate initial shifts
     valid_agents = [agent["name"] for agent in agents]
@@ -237,6 +244,27 @@ def _build_planning_payload(payload, runtime_config):
             if vacation not in valid_vacations:
                 return {"error": f"Invalid vacation: {vacation}"}, 400
 
+    validated_existing_assignments = {}
+    for agent_name, assignments in existing_assignments.items():
+        if agent_name not in valid_agents:
+            return {"error": f"Invalid agent: {agent_name}"}, 400
+        if not isinstance(assignments, list):
+            return {"error": f"existing_assignments for {agent_name} must be a list"}, 400
+        for assignment in assignments:
+            if (
+                not isinstance(assignment, (list, tuple))
+                or len(assignment) != 2
+                or not isinstance(assignment[0], str)
+                or not isinstance(assignment[1], str)
+            ):
+                return {
+                    "error": "Each existing assignment must be [day, vacation] with string values"
+                }, 400
+            day, vacation = assignment
+            if vacation not in valid_vacations:
+                return {"error": f"Invalid vacation: {vacation}"}, 400
+            validated_existing_assignments[(agent_name, day)] = vacation
+
     for chunk_start, chunk_end in periods:
         # Convert the start and end dates into strings
         start_date_str = chunk_start.strftime("%Y-%m-%d")
@@ -257,6 +285,7 @@ def _build_planning_payload(payload, runtime_config):
                 initial_shifts,
                 planning_start_date=start_date_str,
                 runtime_config=runtime_config,
+                existing_assignments=validated_existing_assignments,
             )
         except ValueError as exc:
             return {"error": str(exc)}, 400
@@ -298,6 +327,7 @@ def _build_planning_payload(payload, runtime_config):
         "vacation_durations": vacation_durations,
         "vacation_colors": runtime_config.get("vacation_colors", {}),
         "assignable_vacations": assignable_vacations,
+        "assignment_labels": assignment_labels,
         "week_schedule": original_week_schedule,
         "holidays": holidays,
         "unavailable": unavailable,
@@ -370,7 +400,7 @@ def _parse_manual_entries(manual_entries, runtime_config, start_date, end_date):
         (runtime_config.get("restriction_types_durations") or {}).keys()
     )
 
-    initial_shifts = {}
+    existing_assignments = {}
     status_entries = []
     warnings = []
     for entry in manual_entries:
@@ -397,7 +427,7 @@ def _parse_manual_entries(manual_entries, runtime_config, start_date, end_date):
             if value not in valid_vacations:
                 return None, None, None, (jsonify({"error": f"Invalid vacation: {value}"}), 400)
             day_label = format_day_label(entry_date)
-            initial_shifts.setdefault(agent, []).append((day_label, value))
+            existing_assignments.setdefault(agent, []).append((day_label, value))
         elif entry_type == "status":
             if value in {"unavailable", "training", "vacations"}:
                 pass  # These are valid status types
@@ -424,7 +454,7 @@ def _parse_manual_entries(manual_entries, runtime_config, start_date, end_date):
         else:
             return None, None, None, (jsonify({"error": f"Invalid entry type: {entry_type}"}), 400)
 
-    return initial_shifts, status_entries, warnings, None
+    return existing_assignments, status_entries, warnings, None
 
 
 def _inject_manual_status_entries(runtime_config, status_entries):
@@ -460,6 +490,54 @@ def _inject_manual_status_entries(runtime_config, status_entries):
             target.setdefault("restrictions", [])
             target["restrictions"].append({"date": day_str, "type": restriction_type})
     return injected_config, warnings
+
+
+def _build_day_label_iso_lookup(start_date_str, end_date_str):
+    start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
+    end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
+    lookup = {}
+    current = start_date
+    while current <= end_date:
+        lookup[format_day_label(current)] = current.strftime("%Y-%m-%d")
+        current += timedelta(days=1)
+    return lookup
+
+
+def _detect_modified_existing_assignments(result, existing_assignments, runtime_config, start_date_str, end_date_str):
+    catalog = build_vacation_catalog(runtime_config)
+    metadata_by_assignment = catalog["assignment_metadata"]
+    day_to_iso = _build_day_label_iso_lookup(start_date_str, end_date_str)
+    final_by_agent_day = {}
+    for agent_name, shifts in (result.get("planning") or {}).items():
+        for day, vacation in shifts:
+            final_by_agent_day[(agent_name, day)] = vacation
+
+    modifications = []
+    for agent_name, assignments in (existing_assignments or {}).items():
+        for day, initial_vacation in assignments:
+            final_vacation = final_by_agent_day.get((agent_name, day))
+            if final_vacation == initial_vacation:
+                continue
+
+            if final_vacation is None:
+                change_type = "cleared"
+            elif metadata_by_assignment.get(final_vacation) and metadata_by_assignment[final_vacation].is_half:
+                change_type = "changed_to_half"
+            else:
+                change_type = "changed_to_full"
+
+            modifications.append(
+                {
+                    "agent": agent_name,
+                    "date": day_to_iso.get(day),
+                    "day": day,
+                    "initial_value": initial_vacation,
+                    "final_value": final_vacation,
+                    "change_type": change_type,
+                }
+            )
+    return modifications
+
 
 def _build_suggestions_from_context(manual_entries, warnings, unsat_reason=None, blocking_reasons=None):
     suggestions = []
@@ -1032,7 +1110,7 @@ def optimize_existing_planning_route():
     if date_error is not None:
         return date_error
 
-    initial_shifts, status_entries, warnings, entries_error = _parse_manual_entries(
+    existing_assignments, status_entries, warnings, entries_error = _parse_manual_entries(
         payload.get("manual_entries", []), runtime_config, start_date, end_date
     )
     if entries_error is not None:
@@ -1046,7 +1124,8 @@ def optimize_existing_planning_route():
         payload={
             "start_date": payload["start_date"],
             "end_date": payload["end_date"],
-            "initial_shifts": initial_shifts,
+            "initial_shifts": {},
+            "existing_assignments": existing_assignments,
         },
         runtime_config=effective_runtime_config,
     )
@@ -1069,7 +1148,8 @@ def optimize_existing_planning_route():
                 planning_payload={
                     "start_date": payload["start_date"],
                     "end_date": payload["end_date"],
-                    "initial_shifts": initial_shifts,
+                    "initial_shifts": {},
+                    "existing_assignments": existing_assignments,
                 },
                 runtime_config=effective_runtime_config,
             )
@@ -1126,6 +1206,13 @@ def optimize_existing_planning_route():
     result["status"] = status
     result["warnings"] = warnings
     result["suggestions"] = suggestions
+    result["modified_existing_assignments"] = _detect_modified_existing_assignments(
+        result,
+        existing_assignments,
+        effective_runtime_config,
+        payload["start_date"],
+        payload["end_date"],
+    )
     result["meta"] = {
         "manual_cell_count": len(manual_entries),
         "conflict_count": len(warnings),
@@ -1312,6 +1399,7 @@ def generate_planning(
     initial_shifts,
     planning_start_date=None,
     runtime_config=None,
+    existing_assignments=None,
 ):
     # Public facade kept stable for existing route and tests.
     effective_runtime_config = runtime_config or get_active_config()
@@ -1324,6 +1412,7 @@ def generate_planning(
         initial_shifts=initial_shifts,
         runtime_config=effective_runtime_config,
         planning_start_date=planning_start_date,
+        existing_assignments=existing_assignments,
     )
 
 set_active_config(get_active_config())

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -3,33 +3,57 @@
     {
       "name": "Agent1",
       "preferences": {
-        "preferred": ["Jour", "CDP"],
-        "avoid": ["Nuit"]
+        "preferred": [
+          "Jour",
+          "CDP"
+        ],
+        "avoid": [
+          "Nuit"
+        ]
       },
       "restriction": [],
-      "unavailable": ["15-01-2026"],
-      "training": ["20-01-2026"],
+      "unavailable": [
+        "15-01-2026"
+      ],
+      "training": [
+        "20-01-2026"
+      ],
       "exclusion": [],
       "vacations": [
-        { "start": "02-03-2026", "end": "08-03-2026" }
+        {
+          "start": "02-03-2026",
+          "end": "08-03-2026"
+        }
       ]
     },
     {
       "name": "Agent2",
       "preferences": {
-        "preferred": ["Nuit"],
-        "avoid": ["Jour", "CDP"]
+        "preferred": [
+          "Nuit"
+        ],
+        "avoid": [
+          "Jour",
+          "CDP"
+        ]
       },
-      "restriction": ["Jour"],
+      "restriction": [
+        "Jour"
+      ],
       "unavailable": [],
       "training": [],
-      "exclusion": ["01-01-2026"],
+      "exclusion": [
+        "01-01-2026"
+      ],
       "vacations": []
     },
     {
       "name": "Agent3",
       "preferences": {
-        "preferred": ["Jour", "CDP"],
+        "preferred": [
+          "Jour",
+          "CDP"
+        ],
         "avoid": []
       },
       "restriction": [],
@@ -37,11 +61,18 @@
       "training": [],
       "exclusion": [],
       "vacations": [
-        { "start": "10-08-2026", "end": "23-08-2026" }
+        {
+          "start": "10-08-2026",
+          "end": "23-08-2026"
+        }
       ]
     }
   ],
-  "vacations": ["Jour", "Nuit", "CDP"],
+  "vacations": [
+    "Jour",
+    "Nuit",
+    "CDP"
+  ],
   "staffing_requirements": {
     "Jour": 1,
     "Nuit": 1,
@@ -78,5 +109,52 @@
     "optimize_period_balance": false,
     "period_balance_weight": 2,
     "min_free_weekends_per_horizon": 3
+  },
+  "half_vacations": {
+    "Jour": {
+      "enabled": true,
+      "penalty": 500,
+      "segments": [
+        {
+          "name": "Jour matin",
+          "label": "J matin",
+          "duration": 6
+        },
+        {
+          "name": "Jour après-midi",
+          "label": "J aprem",
+          "duration": 6
+        }
+      ]
+    },
+    "Nuit": {
+      "enabled": true,
+      "penalty": 700,
+      "segments": [
+        {
+          "name": "Nuit début",
+          "label": "N début",
+          "duration": 6,
+          "is_night": true,
+          "requires_next_day_rest": true
+        },
+        {
+          "name": "Nuit fin",
+          "label": "N fin",
+          "duration": 6,
+          "is_night": true,
+          "requires_next_day_rest": true
+        }
+      ]
+    }
+  },
+  "vacation_colors": {
+    "Jour": "#75FA79",
+    "Jour matin": "#B9F6CA",
+    "Jour après-midi": "#00C853",
+    "Nuit": "#9175FA",
+    "Nuit début": "#B39DDB",
+    "Nuit fin": "#673AB7",
+    "CDP": "#FFD966"
   }
 }

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -105,6 +105,25 @@
           "minimum": 0
         }
       }
+    },
+    "half_vacations": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/half_vacation"
+      }
+    },
+    "vacation_colors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^#[0-9A-Fa-f]{6}$"
+      }
+    },
+    "vacation_metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/vacation_metadata"
+      }
     }
   },
   "$defs": {
@@ -203,6 +222,74 @@
               }
             }
           }
+        }
+      }
+    },
+    "vacation_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "is_night": {
+          "type": "boolean"
+        },
+        "requires_next_day_rest": {
+          "type": "boolean"
+        }
+      }
+    },
+    "half_vacation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "penalty",
+        "segments"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "penalty": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "segments": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/half_vacation_segment"
+          }
+        }
+      }
+    },
+    "half_vacation_segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "duration"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/shift"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "duration": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "is_night": {
+          "type": "boolean"
+        },
+        "requires_next_day_rest": {
+          "type": "boolean"
         }
       }
     }

--- a/backend/solver/catalog.py
+++ b/backend/solver/catalog.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_NIGHT_SHIFT_NAMES = {"Nuit"}
+
+
+@dataclass(frozen=True)
+class AssignmentMetadata:
+    name: str
+    parent: str
+    duration: int
+    is_half: bool = False
+    segment: str | None = None
+    label: str | None = None
+    penalty: int = 0
+    is_night: bool = False
+    requires_next_day_rest: bool = False
+
+
+def _duration_to_tenths(value: Any, field_name: str) -> int:
+    try:
+        duration = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a positive number") from exc
+    if duration <= 0:
+        raise ValueError(f"{field_name} must be a positive number")
+    return int(round(duration * 10))
+
+
+def _is_enabled_half_config(half_config: dict[str, Any]) -> bool:
+    return bool(half_config.get("enabled", True))
+
+
+def build_vacation_catalog(config: dict[str, Any]) -> dict[str, Any]:
+    """Build a normalized assignment catalog from user-facing vacation config."""
+    coverage_vacations = list(config.get("vacations") or [])
+    configured_durations = config.get("vacation_durations") or {}
+    half_vacations = config.get("half_vacations") or {}
+    vacation_metadata = config.get("vacation_metadata") or {}
+
+    assignment_metadata: dict[str, AssignmentMetadata] = {}
+    assignable_vacations: list[str] = []
+    coverage_segments: dict[str, list[str]] = {}
+    segment_covering_assignments: dict[tuple[str, str], list[str]] = {}
+    half_vacation_names: set[str] = set()
+
+    for parent in coverage_vacations:
+        if parent not in configured_durations:
+            raise ValueError(
+                "Missing vacation_durations entries for configured vacations: "
+                f"{parent}"
+            )
+        parent_duration = _duration_to_tenths(
+            configured_durations[parent], f"vacation_durations[{parent}]"
+        )
+        parent_metadata = vacation_metadata.get(parent) or {}
+        parent_is_night = bool(parent_metadata.get("is_night", parent in DEFAULT_NIGHT_SHIFT_NAMES))
+        parent_requires_rest = bool(
+            parent_metadata.get("requires_next_day_rest", parent_is_night)
+        )
+        assignment_metadata[parent] = AssignmentMetadata(
+            name=parent,
+            parent=parent,
+            duration=parent_duration,
+            is_half=False,
+            label=parent_metadata.get("label", parent),
+            is_night=parent_is_night,
+            requires_next_day_rest=parent_requires_rest,
+        )
+        assignable_vacations.append(parent)
+
+        parent_half_config = half_vacations.get(parent)
+        if isinstance(parent_half_config, dict) and _is_enabled_half_config(parent_half_config):
+            segments = parent_half_config.get("segments") or []
+            if not segments:
+                coverage_segments[parent] = [parent]
+                segment_covering_assignments[(parent, parent)] = [parent]
+                continue
+
+            segment_names: list[str] = []
+            segment_duration_sum = 0
+            penalty = int(parent_half_config.get("penalty", 0))
+            for index, segment in enumerate(segments):
+                if not isinstance(segment, dict):
+                    raise ValueError(f"half_vacations[{parent}].segments[{index}] must be an object")
+                segment_name = segment.get("name")
+                if not segment_name or not isinstance(segment_name, str):
+                    raise ValueError(f"half_vacations[{parent}].segments[{index}].name is required")
+                if segment_name in assignment_metadata:
+                    raise ValueError(f"Duplicate assignable vacation name: {segment_name}")
+                segment_duration = _duration_to_tenths(
+                    segment.get("duration"),
+                    f"half_vacations[{parent}].segments[{index}].duration",
+                )
+                segment_duration_sum += segment_duration
+                segment_names.append(segment_name)
+                half_vacation_names.add(segment_name)
+                segment_is_night = bool(segment.get("is_night", parent_is_night))
+                segment_requires_rest = bool(
+                    segment.get("requires_next_day_rest", segment_is_night or parent_requires_rest)
+                )
+                assignment_metadata[segment_name] = AssignmentMetadata(
+                    name=segment_name,
+                    parent=parent,
+                    duration=segment_duration,
+                    is_half=True,
+                    segment=segment_name,
+                    label=segment.get("label", segment_name),
+                    penalty=penalty,
+                    is_night=segment_is_night,
+                    requires_next_day_rest=segment_requires_rest,
+                )
+                assignable_vacations.append(segment_name)
+                segment_covering_assignments[(parent, segment_name)] = [parent, segment_name]
+
+            if segment_duration_sum != parent_duration:
+                raise ValueError(
+                    f"half_vacations[{parent}] segment durations must sum to "
+                    f"vacation_durations[{parent}]"
+                )
+            coverage_segments[parent] = segment_names
+        else:
+            coverage_segments[parent] = [parent]
+            segment_covering_assignments[(parent, parent)] = [parent]
+
+    return {
+        "coverage_vacations": coverage_vacations,
+        "assignable_vacations": assignable_vacations,
+        "assignment_metadata": assignment_metadata,
+        "coverage_segments": coverage_segments,
+        "segment_covering_assignments": segment_covering_assignments,
+        "half_vacation_names": half_vacation_names,
+    }
+
+
+def _metadata_map(ctx_or_catalog):
+    if isinstance(ctx_or_catalog, dict):
+        return ctx_or_catalog.get("assignment_metadata", {})
+    return getattr(ctx_or_catalog, "assignment_metadata", {})
+
+
+def assignment_parent(ctx, assignment: str) -> str:
+    metadata = _metadata_map(ctx).get(assignment)
+    return metadata.parent if metadata else assignment
+
+
+def is_half_assignment(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.is_half)
+
+
+def is_night_assignment(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.is_night)
+
+
+def requires_next_day_rest(ctx, assignment: str) -> bool:
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.requires_next_day_rest)
+
+
+def assignment_matches_choice(ctx, assignment: str, choices: list[str] | set[str]) -> bool:
+    if assignment in choices:
+        return True
+    metadata = _metadata_map(ctx).get(assignment)
+    return bool(metadata and metadata.parent in choices)

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -41,11 +41,10 @@ def register(registry: ConstraintRegistry) -> None:
     - Require at least one shift per agent
     - Cover daily shifts
     - Avoid day after night
-    - Limit CDP per week
+    - Limit CDP per week (historical hard business exception)
     - Block unavailable days
     - Block training days
     - Block leave and compute paid hours
-    - Limit day shifts per week
     - Block night before unavailable
     - Block night before training
     - Limit pre/post training
@@ -283,6 +282,9 @@ def limit_cdp_per_week(ctx: SolverContext) -> None:
     """
     Limits the number of CDP shifts per week to two.
 
+    CDP keeps this hard historical business exception even though the general
+    workload rule is hour-based through solver.max_weekly_hours.
+
     This constraint is applied per agent and per week in the week's schedule.
     For each agent, it ensures that the sum of all CDP shift variables for that agent
     on that week is less than or equal to two. This prevents the agent from being
@@ -407,36 +409,6 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                             ctx.model.Add(ctx.planning[(agent_name, weekend_str, vacation)] == 0)
 
     ctx.leave_paid_hours_by_day = leave_paid_hours_by_day
-
-
-def limit_day_shifts_per_week(ctx: SolverContext) -> None:
-    """
-    Limits the number of day shifts per week to three.
-
-    This constraint is applied per agent and per week in the week's schedule.
-    For each agent, it ensures that the sum of all day shift variables for that agent
-    on that week is less than or equal to three. This prevents the agent from being
-    assigned more than three day shifts per week.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    if not _has_shift(ctx, DAY_SHIFT):
-        return
-
-    week_days = [
-        (day, datetime.strptime(day.split(" ")[1], "%d-%m")) for day in ctx.week_schedule
-    ]
-    weeks_dict = defaultdict(list)
-    for day_str, day_date in week_days:
-        week_number = day_date.isocalendar()[:2]
-        weeks_dict[week_number].append(day_str)
-
-    for agent in ctx.agents:
-        agent_name = agent["name"]
-        for days in weeks_dict.values():
-            ctx.model.Add(sum(ctx.planning[(agent_name, day, DAY_SHIFT)] for day in days) <= 3)
-
 
 def block_night_before_unavailable(ctx: SolverContext) -> None:
     """

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -38,7 +38,6 @@ def register(registry: ConstraintRegistry) -> None:
     The hard constraints are:
     - Apply initial shifts
     - Limit one shift per day
-    - Require at least one shift per agent
     - Cover daily shifts
     - Avoid day after night
     - Limit CDP per week (historical hard business exception)
@@ -54,7 +53,6 @@ def register(registry: ConstraintRegistry) -> None:
     """
     registry.register_hard(apply_initial_shifts)
     registry.register_hard(limit_one_shift_per_day)
-    registry.register_hard(require_at_least_one_shift_per_agent)
     registry.register_hard(cover_daily_shifts)
     registry.register_hard(enforce_full_weekend_composition)
     registry.register_hard(enforce_min_free_weekends_per_horizon)
@@ -115,29 +113,6 @@ def limit_one_shift_per_day(ctx: SolverContext) -> None:
                 sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations)
                 <= 1
             )
-
-
-def require_at_least_one_shift_per_agent(ctx: SolverContext) -> None:
-    """
-    Requires each agent to have at least one shift per week.
-
-    This constraint is applied per agent and ensures that the sum of all shift variables
-    for that agent on all days in the week's schedule is greater than or equal to one.
-    This prevents the agent from being assigned no shifts at all.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    for agent in ctx.agents:
-        agent_name = agent["name"]
-        ctx.model.Add(
-            sum(
-                ctx.planning[(agent_name, day, vacation)]
-                for day in ctx.week_schedule
-                for vacation in ctx.assignable_vacations
-            )
-            >= 1
-        )
 
 
 def cover_daily_shifts(ctx: SolverContext) -> None:

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -1,6 +1,13 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+from ..catalog import (
+    assignment_matches_choice,
+    assignment_parent,
+    is_half_assignment,
+    is_night_assignment,
+    requires_next_day_rest,
+)
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
 from ..utils import day_token
@@ -57,7 +64,6 @@ def register(registry: ConstraintRegistry) -> None:
     registry.register_hard(block_unavailable_days)
     registry.register_hard(block_training_days)
     registry.register_hard(block_leave_and_compute_paid_hours)
-    registry.register_hard(limit_day_shifts_per_week)
     registry.register_hard(block_night_before_unavailable)
     registry.register_hard(block_night_before_training)
     registry.register_hard(limit_pre_post_training)
@@ -85,7 +91,7 @@ def apply_initial_shifts(ctx: SolverContext) -> None:
         for day, vacation in shifts:
             if (
                 agent_name in valid_agents
-                and vacation in ctx.vacations
+                and vacation in ctx.assignable_vacations
                 and (day in ctx.previous_week_schedule or day in ctx.week_schedule)
             ):
                 ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 1)
@@ -107,7 +113,7 @@ def limit_one_shift_per_day(ctx: SolverContext) -> None:
         agent_name = agent["name"]
         for day in ctx.week_schedule:
             ctx.model.Add(
-                sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.vacations)
+                sum(ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations)
                 <= 1
             )
 
@@ -129,42 +135,46 @@ def require_at_least_one_shift_per_agent(ctx: SolverContext) -> None:
             sum(
                 ctx.planning[(agent_name, day, vacation)]
                 for day in ctx.week_schedule
-                for vacation in ctx.vacations
+                for vacation in ctx.assignable_vacations
             )
             >= 1
         )
 
 
 def cover_daily_shifts(ctx: SolverContext) -> None:
-    """
-    Covers all daily shifts with configurable staffing per day.
-
-    This constraint is applied per day in the week's schedule.
-    For each day and each configured vacation, it ensures that the number of
-    assigned agents matches staffing_requirements[vacation].
-
-    For days that are part of a weekend or fall on a holiday, and for CDP shifts,
-    it ensures that the sum of all shift variables for all agents on that day is zero.
-    This prevents CDP shifts from being assigned on weekends or holidays.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Covers all parent vacation segments with assignable full/half vacations."""
     for day in ctx.week_schedule:
         day_date = day.split(" ")[1]
         day_is_weekend = day.startswith(("Sam", "Dim"))
-        for vacation in ctx.vacations:
-            required_agents = ctx.staffing_requirements.get(vacation, 1)
-            if vacation == CDP_SHIFT and (day_is_weekend or day_date in ctx.holidays):
+        day_is_holiday = day_date in ctx.holidays
+
+        for assignment in ctx.assignable_vacations:
+            parent = assignment_parent(ctx, assignment)
+            if is_half_assignment(ctx, assignment) and (day_is_weekend or day_is_holiday):
                 ctx.model.Add(
-                    sum(ctx.planning[(agent["name"], day, CDP_SHIFT)] for agent in ctx.agents)
+                    sum(ctx.planning[(agent["name"], day, assignment)] for agent in ctx.agents)
                     == 0
                 )
-            else:
+            if parent == CDP_SHIFT and (day_is_weekend or day_is_holiday):
+                ctx.model.Add(
+                    sum(ctx.planning[(agent["name"], day, assignment)] for agent in ctx.agents)
+                    == 0
+                )
+
+        for vacation in ctx.vacations:
+            required_agents = ctx.staffing_requirements.get(vacation, 1)
+            if vacation == CDP_SHIFT and (day_is_weekend or day_is_holiday):
+                required_agents = 0
+            for segment in ctx.coverage_segments.get(vacation, [vacation]):
+                covering_assignments = ctx.segment_covering_assignments.get(
+                    (vacation, segment), [vacation]
+                )
                 ctx.model.Add(
                     sum(
-                        ctx.planning[(agent["name"], day, vacation)]
+                        ctx.planning[(agent["name"], day, assignment)]
                         for agent in ctx.agents
+                        for assignment in covering_assignments
+                        if assignment in ctx.assignable_vacations
                     )
                     == required_agents
                 )
@@ -187,10 +197,10 @@ def enforce_full_weekend_composition(ctx: SolverContext) -> None:
         for agent in ctx.agents:
             agent_name = agent["name"]
             saturday_work = sum(
-                ctx.planning[(agent_name, day, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, day, vacation)] for vacation in ctx.assignable_vacations
             )
             sunday_work = sum(
-                ctx.planning[(agent_name, next_day, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, next_day, vacation)] for vacation in ctx.assignable_vacations
             )
             ctx.model.Add(saturday_work == sunday_work)
 
@@ -235,10 +245,10 @@ def enforce_min_free_weekends_per_horizon(ctx: SolverContext) -> None:
                 f"{agent_name}_works_weekend_hard_{saturday}_{sunday}"
             )
             saturday_work = sum(
-                ctx.planning[(agent_name, saturday, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, saturday, vacation)] for vacation in ctx.assignable_vacations
             )
             sunday_work = sum(
-                ctx.planning[(agent_name, sunday, vacation)] for vacation in ctx.vacations
+                ctx.planning[(agent_name, sunday, vacation)] for vacation in ctx.assignable_vacations
             )
             ctx.model.Add(saturday_work == 1).OnlyEnforceIf(works_weekend)
             ctx.model.Add(sunday_work == 1).OnlyEnforceIf(works_weekend)
@@ -249,31 +259,25 @@ def enforce_min_free_weekends_per_horizon(ctx: SolverContext) -> None:
         ctx.model.Add(sum(worked_weekend_vars) <= max_worked_weekends)
 
 def avoid_day_after_night(ctx: SolverContext) -> None:
-    """
-    Avoids assigning a day shift after a night shift.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that if the agent is assigned a night shift on a given day,
-    the agent is not assigned a day shift on the next day.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    """Blocks assignments that require rest on the next day."""
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
         agent_name = agent["name"]
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
-            night_var = ctx.planning[(agent_name, day, NIGHT_SHIFT)]
-            for vacation in ctx.vacations:
-                if vacation == NIGHT_SHIFT:
-                    continue
-                ctx.model.Add(ctx.planning[(agent_name, next_day, vacation)] == 0).OnlyEnforceIf(
-                    night_var
-                )
-
+            for rest_assignment in rest_trigger_assignments:
+                rest_var = ctx.planning[(agent_name, day, rest_assignment)]
+                for assignment in ctx.assignable_vacations:
+                    if is_night_assignment(ctx, assignment):
+                        continue
+                    ctx.model.Add(ctx.planning[(agent_name, next_day, assignment)] == 0).OnlyEnforceIf(
+                        rest_var
+                    )
 
 def limit_cdp_per_week(ctx: SolverContext) -> None:
     """
@@ -314,7 +318,7 @@ def block_unavailable_days(ctx: SolverContext) -> None:
         for unavailable_day in unavailable_days:
             for day in ctx.week_schedule:
                 if unavailable_day in day:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 0)
 
 
@@ -336,7 +340,7 @@ def block_training_days(ctx: SolverContext) -> None:
         for training_day in training_days:
             for day in ctx.week_schedule:
                 if training_day in day:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day, vacation)] == 0)
 
 
@@ -385,7 +389,7 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                         continue
 
                 if vacation_start <= day_date <= vacation_end:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day_str, vacation)] == 0)
                     if day_date.weekday() < 6:
                         leave_paid_hours_by_day[(agent_name, day_str)] = ctx.conge_duration
@@ -399,7 +403,7 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                         weekend_str in ctx.week_schedule
                         or weekend_str in ctx.previous_week_schedule
                     ):
-                        for vacation in ctx.vacations:
+                        for vacation in ctx.assignable_vacations:
                             ctx.model.Add(ctx.planning[(agent_name, weekend_str, vacation)] == 0)
 
     ctx.leave_paid_hours_by_day = leave_paid_hours_by_day
@@ -445,7 +449,10 @@ def block_night_before_unavailable(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
@@ -454,7 +461,8 @@ def block_night_before_unavailable(ctx: SolverContext) -> None:
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
             if any(unavailable_day in next_day for unavailable_day in unavailable_days):
-                ctx.model.Add(ctx.planning[(agent_name, day, NIGHT_SHIFT)] == 0)
+                for assignment in rest_trigger_assignments:
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)
 
 
 def block_night_before_training(ctx: SolverContext) -> None:
@@ -468,7 +476,10 @@ def block_night_before_training(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    rest_trigger_assignments = [
+        assignment for assignment in ctx.assignable_vacations if requires_next_day_rest(ctx, assignment)
+    ]
+    if not rest_trigger_assignments:
         return
 
     for agent in ctx.agents:
@@ -477,21 +488,12 @@ def block_night_before_training(ctx: SolverContext) -> None:
         for day_idx, day in enumerate(ctx.week_schedule[:-1]):
             next_day = ctx.week_schedule[day_idx + 1]
             if any(training_day in next_day for training_day in training_days):
-                ctx.model.Add(ctx.planning[(agent_name, day, NIGHT_SHIFT)] == 0)
+                for assignment in rest_trigger_assignments:
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)
 
 
 def limit_pre_post_training(ctx: SolverContext) -> None:
-    """
-    Limits vacation types before and after training days.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that the agent is not assigned any vacation type
-    except for CDP and night shifts on the day after a training day, and that the agent
-    is not assigned any vacation type except for CDP on the day before a training day.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Limits assignment types before and after training days."""
     if not _has_shift(ctx, CDP_SHIFT):
         return
 
@@ -505,19 +507,16 @@ def limit_pre_post_training(ctx: SolverContext) -> None:
 
             if day_idx > 0:
                 previous_day = ctx.week_schedule[day_idx - 1]
-                for vacation in ctx.vacations:
-                    if vacation != CDP_SHIFT:
-                        ctx.model.Add(ctx.planning[(agent_name, previous_day, vacation)] == 0)
+                for assignment in ctx.assignable_vacations:
+                    if assignment_parent(ctx, assignment) != CDP_SHIFT:
+                        ctx.model.Add(ctx.planning[(agent_name, previous_day, assignment)] == 0)
 
             if day_idx < len(ctx.week_schedule) - 1:
                 next_day = ctx.week_schedule[day_idx + 1]
-                allowed_vacations = [CDP_SHIFT]
-                if _has_shift(ctx, NIGHT_SHIFT):
-                    allowed_vacations.append(NIGHT_SHIFT)
-                for vacation in ctx.vacations:
-                    if vacation not in allowed_vacations:
-                        ctx.model.Add(ctx.planning[(agent_name, next_day, vacation)] == 0)
-
+                for assignment in ctx.assignable_vacations:
+                    if assignment_parent(ctx, assignment) == CDP_SHIFT or is_night_assignment(ctx, assignment):
+                        continue
+                    ctx.model.Add(ctx.planning[(agent_name, next_day, assignment)] == 0)
 
 def block_exclusion_days(ctx: SolverContext) -> None:
     """
@@ -538,22 +537,16 @@ def block_exclusion_days(ctx: SolverContext) -> None:
             for day_str in ctx.week_schedule:
                 day_date = day_str.split(" ")[1]
                 if exclusion_day == day_date:
-                    for vacation in ctx.vacations:
+                    for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day_str, vacation)] == 0)
 
 
 def block_monday_night_after_weekend_nights(ctx: SolverContext) -> None:
-    """
-    Blocks Monday night shifts after weekend night shifts.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that if the agent is assigned a night shift on a Saturday,
-    the agent is not assigned a night shift on the following Monday.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
-    if not _has_shift(ctx, NIGHT_SHIFT):
+    """Blocks Monday night assignments after weekend night assignments."""
+    night_assignments = [
+        assignment for assignment in ctx.assignable_vacations if is_night_assignment(ctx, assignment)
+    ]
+    if not night_assignments:
         return
 
     for agent in ctx.agents:
@@ -565,29 +558,24 @@ def block_monday_night_after_weekend_nights(ctx: SolverContext) -> None:
                 if sunday_idx < len(ctx.week_schedule) and monday_idx < len(ctx.week_schedule):
                     sunday = ctx.week_schedule[sunday_idx]
                     monday = ctx.week_schedule[monday_idx]
-                    saturday_night = ctx.planning[(agent_name, day, NIGHT_SHIFT)]
-                    sunday_night = ctx.planning[(agent_name, sunday, NIGHT_SHIFT)]
-                    ctx.model.Add(
-                        ctx.planning[(agent_name, monday, NIGHT_SHIFT)] == 0
-                    ).OnlyEnforceIf(
-                        [saturday_night, sunday_night]
-                    )
-
+                    for saturday_assignment in night_assignments:
+                        for sunday_assignment in night_assignments:
+                            for monday_assignment in night_assignments:
+                                ctx.model.Add(
+                                    ctx.planning[(agent_name, monday, monday_assignment)] == 0
+                                ).OnlyEnforceIf(
+                                    [
+                                        ctx.planning[(agent_name, day, saturday_assignment)],
+                                        ctx.planning[(agent_name, sunday, sunday_assignment)],
+                                    ]
+                                )
 
 def apply_agent_restrictions(ctx: SolverContext) -> None:
-    """
-    Applies agent-specific vacation restrictions.
-
-    This constraint is applied per agent and per day in the week's schedule.
-    For each agent, it ensures that the agent is not assigned any restricted vacation type
-    on any day of the week.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+    """Applies agent-specific vacation/assignment restrictions."""
     for agent in ctx.agents:
         agent_name = agent["name"]
-        restricted_vacations = agent.get("restriction", [])
+        restricted_vacations = set(agent.get("restriction", []))
         for day in ctx.week_schedule:
-            for restricted_vacation in restricted_vacations:
-                ctx.model.Add(ctx.planning[(agent_name, day, restricted_vacation)] == 0)
+            for assignment in ctx.assignable_vacations:
+                if assignment_matches_choice(ctx, assignment, restricted_vacations):
+                    ctx.model.Add(ctx.planning[(agent_name, day, assignment)] == 0)

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -16,35 +16,26 @@ def register(registry: ConstraintRegistry) -> None:
     :param registry: The registry to which the constraints should be registered.
     :type registry: ConstraintRegistry
     """
-    registry.register_mixed(limit_weekly_nights_and_hours)
+    registry.register_mixed(limit_weekly_worked_hours)
 
 
-def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
-    """
-    Limits weekly night shifts and total worked hours.
-
-    This constraint is applied per agent and per week in the week's schedule.
-    For each agent, it allows at most 3 night shifts per week and caps worked
-    hours using solver.max_weekly_hours. The worked-hours cap counts all
-    configured vacations assigned by the solver and does not include paid leave.
-
-    :param ctx: The solver context containing the problem data and the model.
-    :type ctx: SolverContext
-    """
+def limit_weekly_worked_hours(ctx: SolverContext) -> None:
+    """Caps weekly worked hours using solver.max_weekly_hours."""
     for agent in ctx.agents:
         agent_name = agent["name"]
 
         for week in ctx.weeks_split:
-            if NIGHT_SHIFT in ctx.vacations:
-                ctx.model.Add(
-                    sum(ctx.planning[(agent_name, day, NIGHT_SHIFT)] for day in week) <= 3
-                )
-
+            assignable_vacations = getattr(ctx, "assignable_vacations", None) or ctx.vacations
             total_hours = sum(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in ctx.vacations
+                    for vacation in assignable_vacations
                 )
                 for day in week
             )
             ctx.model.Add(total_hours <= ctx.max_weekly_hours)
+
+
+def limit_weekly_nights_and_hours(ctx: SolverContext) -> None:
+    """Backward-compatible alias for the weekly worked-hours cap."""
+    limit_weekly_worked_hours(ctx)

--- a/backend/solver/constraints/soft.py
+++ b/backend/solver/constraints/soft.py
@@ -1,5 +1,6 @@
 from ortools.sat.python import cp_model
 
+from ..catalog import assignment_parent
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
 from ..utils import split_by_month_or_period
@@ -22,7 +23,7 @@ def _assignment_sum(ctx: SolverContext, agent_name: str, day: str, vacations: li
     :return: The sum of assignments for the given agent, day, and list of vacations.
     :rtype: int
     """
-    relevant = [vacation for vacation in vacations if vacation in ctx.vacations]
+    relevant = [vacation for vacation in vacations if vacation in ctx.assignable_vacations]
     if not relevant:
         return 0
     return sum(ctx.planning[(agent_name, day, vacation)] for vacation in relevant)
@@ -41,10 +42,14 @@ def _working_vacations(ctx: SolverContext) -> list[str]:
     :return: A list of working vacations.
     :rtype: list[str]
     """
-    vacations = [vacation for vacation in ctx.vacations if vacation != CDP_SHIFT]
+    vacations = [
+        vacation
+        for vacation in ctx.assignable_vacations
+        if assignment_parent(ctx, vacation) != CDP_SHIFT
+    ]
     if vacations:
         return vacations
-    return list(ctx.vacations)
+    return list(ctx.assignable_vacations)
 
 
 def register(registry: ConstraintRegistry) -> None:
@@ -81,7 +86,7 @@ def balance_paid_hours(ctx: SolverContext) -> None:
             list(
                 sum(
                     ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                    for vacation in ctx.vacations
+                    for vacation in ctx.assignable_vacations
                 )
                 + _leave_paid_hours(ctx, agent_name, day)
                 for day in ctx.week_schedule
@@ -120,7 +125,7 @@ def balance_paid_hours_by_period(ctx: SolverContext) -> None:
                 list(
                     sum(
                         ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
-                        for vacation in ctx.vacations
+                        for vacation in ctx.assignable_vacations
                     )
                     + _leave_paid_hours(ctx, agent_name, day)
                     for day in period

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -57,6 +57,7 @@ class SolverContext:
     day_off: dict
     previous_week_schedule: List[str]
     initial_shifts: dict
+    existing_assignments: dict
     holidays: List[str]
     planning_start_date: datetime | None = None
 

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Tuple
 
+from .catalog import AssignmentMetadata
+
 from ortools.sat.python import cp_model
 
 
@@ -62,6 +64,11 @@ class SolverContext:
     planning: Dict[Tuple[str, str, str], cp_model.IntVar] = field(default_factory=dict)
     leave_paid_hours_by_day: Dict[Tuple[str, str], int] = field(default_factory=dict)
     day_dates: Dict[str, datetime] = field(default_factory=dict)
+    assignable_vacations: List[str] = field(default_factory=list)
+    assignment_metadata: Dict[str, AssignmentMetadata] = field(default_factory=dict)
+    coverage_segments: Dict[str, List[str]] = field(default_factory=dict)
+    segment_covering_assignments: Dict[Tuple[str, str], List[str]] = field(default_factory=dict)
+    half_vacation_names: set[str] = field(default_factory=set)
 
     shift_durations: Dict[str, int] = field(default_factory=dict)
     staffing_requirements: Dict[str, int] = field(default_factory=dict)

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from ortools.sat.python import cp_model
 
+from .catalog import build_vacation_catalog
 from .constraints import hard, mixed, soft
 from .context import SolverContext
 from .objective import apply_objective
@@ -22,7 +23,7 @@ def _build_planning_variables(ctx: SolverContext) -> None:
     for agent in ctx.agents:
         agent_name = agent["name"]
         for day in set(ctx.week_schedule + ctx.previous_week_schedule):
-            for vacation in ctx.vacations:
+            for vacation in ctx.assignable_vacations:
                 ctx.planning[(agent_name, day, vacation)] = ctx.model.NewBoolVar(
                     f"planning_{agent_name}_{day}_{vacation}"
                 )
@@ -67,21 +68,18 @@ def _load_shift_durations(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
-    configured_durations = ctx.config["vacation_durations"]
-    missing_vacation_durations = [
-        vacation for vacation in ctx.vacations if vacation not in configured_durations
-    ]
-    if missing_vacation_durations:
-        missing_joined = ", ".join(sorted(missing_vacation_durations))
-        raise ValueError(
-            "Missing vacation_durations entries for configured vacations: "
-            f"{missing_joined}"
-        )
+    catalog = build_vacation_catalog(ctx.config)
+    ctx.assignable_vacations = catalog["assignable_vacations"]
+    ctx.assignment_metadata = catalog["assignment_metadata"]
+    ctx.coverage_segments = catalog["coverage_segments"]
+    ctx.segment_covering_assignments = catalog["segment_covering_assignments"]
+    ctx.half_vacation_names = catalog["half_vacation_names"]
 
     ctx.shift_durations = {
-        vacation: int(configured_durations[vacation] * 10) for vacation in ctx.vacations
+        vacation: metadata.duration
+        for vacation, metadata in ctx.assignment_metadata.items()
     }
-    ctx.conge_duration = int(ctx.config["vacation_durations"]["Conge"] * 10)
+    ctx.conge_duration = int(round(ctx.config["vacation_durations"]["Conge"] * 10))
 
     staffing_config = ctx.config.get("staffing_requirements", {})
     ctx.staffing_requirements = {}
@@ -156,7 +154,7 @@ def _extract_solution(ctx: SolverContext, solver: cp_model.CpSolver):
         agent_name = agent["name"]
         result[agent_name] = []
         for day in ctx.week_schedule:
-            for vacation in ctx.vacations:
+            for vacation in ctx.assignable_vacations:
                 if solver.Value(ctx.planning[(agent_name, day, vacation)]):
                     result[agent_name].append((day, vacation))
     return result
@@ -192,6 +190,8 @@ def generate_planning(
     :return: A dictionary containing the generated planning, where each key is an agent name and each value is a list of tuples, where each tuple contains a day and a vacation type.
     :rtype: Dict[str, List[Tuple[str, str]]]
     """
+    runtime_config = dict(runtime_config)
+    runtime_config.setdefault("vacations", vacations)
     model = cp_model.CpModel()
     ctx = SolverContext(
         model=model,

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -169,6 +169,7 @@ def generate_planning(
     initial_shifts,
     runtime_config,
     planning_start_date=None,
+    existing_assignments=None,
 ):
     """
     Generates a planning based on the given parameters.
@@ -202,6 +203,7 @@ def generate_planning(
         day_off=dayOff,
         previous_week_schedule=previous_week_schedule,
         initial_shifts=initial_shifts,
+        existing_assignments=existing_assignments or {},
         holidays=runtime_config["holidays"],
         planning_start_date=planning_start_date,
     )

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -58,6 +58,20 @@ def apply_objective(ctx: SolverContext) -> None:
         )
     )
 
+    agent_usage_bonus_weight = 5
+    agent_usage_bonus_terms = []
+    for agent in ctx.agents:
+        agent_name = agent["name"]
+        is_used = ctx.model.NewBoolVar(f"{agent_name}_used_at_least_once")
+        worked_assignments = [
+            ctx.planning[(agent_name, day, vacation)]
+            for day in ctx.week_schedule
+            for vacation in ctx.assignable_vacations
+        ]
+        ctx.model.Add(sum(worked_assignments) >= 1).OnlyEnforceIf(is_used)
+        ctx.model.Add(sum(worked_assignments) == 0).OnlyEnforceIf(is_used.Not())
+        agent_usage_bonus_terms.append(is_used * agent_usage_bonus_weight)
+
     preserve_existing_weight = 10000
     change_existing_full_penalty = 1000
     change_existing_half_penalty = 2000
@@ -87,6 +101,7 @@ def apply_objective(ctx: SolverContext) -> None:
         objective_preferred_vacations
         + objective_other_vacations
         + penalized_vacations
+        + cp_model.LinearExpr.Sum(agent_usage_bonus_terms)
         + cp_model.LinearExpr.Sum(preserve_existing_assignments)
         - half_vacation_penalties
         - cp_model.LinearExpr.Sum(change_existing_assignments)

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -58,11 +58,38 @@ def apply_objective(ctx: SolverContext) -> None:
         )
     )
 
+    preserve_existing_weight = 10000
+    change_existing_full_penalty = 1000
+    change_existing_half_penalty = 2000
+    preserve_existing_assignments = []
+    change_existing_assignments = []
+    known_agents = {agent["name"] for agent in ctx.agents}
+    for (agent_name, day), existing_vacation in (ctx.existing_assignments or {}).items():
+        if (
+            agent_name not in known_agents
+            or day not in ctx.week_schedule
+            or existing_vacation not in ctx.assignable_vacations
+        ):
+            continue
+        for vacation in ctx.assignable_vacations:
+            variable = ctx.planning[(agent_name, day, vacation)]
+            if vacation == existing_vacation:
+                preserve_existing_assignments.append(variable * preserve_existing_weight)
+            else:
+                penalty = (
+                    change_existing_half_penalty
+                    if is_half_assignment(ctx, vacation)
+                    else change_existing_full_penalty
+                )
+                change_existing_assignments.append(variable * penalty)
+
     objective = (
         objective_preferred_vacations
         + objective_other_vacations
         + penalized_vacations
+        + cp_model.LinearExpr.Sum(preserve_existing_assignments)
         - half_vacation_penalties
+        - cp_model.LinearExpr.Sum(change_existing_assignments)
         - ctx.weekend_balancing_objective
     )
     if ctx.optimize_period_balance:

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -1,5 +1,6 @@
 from ortools.sat.python import cp_model
 
+from .catalog import assignment_matches_choice, is_half_assignment
 from .context import SolverContext
 
 
@@ -21,8 +22,8 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_preferred
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation in agent["preferences"]["preferred"]
+            for vacation in ctx.assignable_vacations
+            if assignment_matches_choice(ctx, vacation, agent["preferences"]["preferred"])
         )
     )
 
@@ -31,8 +32,8 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_other
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation not in agent["preferences"]["preferred"]
+            for vacation in ctx.assignable_vacations
+            if not assignment_matches_choice(ctx, vacation, agent["preferences"]["preferred"])
         )
     )
 
@@ -41,8 +42,19 @@ def apply_objective(ctx: SolverContext) -> None:
             ctx.planning[(agent["name"], day, vacation)] * weight_avoid
             for agent in ctx.agents
             for day in ctx.week_schedule
-            for vacation in ctx.vacations
-            if vacation in agent["preferences"]["avoid"]
+            for vacation in ctx.assignable_vacations
+            if assignment_matches_choice(ctx, vacation, agent["preferences"]["avoid"])
+        )
+    )
+
+    half_vacation_penalties = cp_model.LinearExpr.Sum(
+        list(
+            ctx.planning[(agent["name"], day, vacation)]
+            * ctx.assignment_metadata[vacation].penalty
+            for agent in ctx.agents
+            for day in ctx.week_schedule
+            for vacation in ctx.assignable_vacations
+            if is_half_assignment(ctx, vacation)
         )
     )
 
@@ -50,6 +62,7 @@ def apply_objective(ctx: SolverContext) -> None:
         objective_preferred_vacations
         + objective_other_vacations
         + penalized_vacations
+        - half_vacation_penalties
         - ctx.weekend_balancing_objective
     )
     if ctx.optimize_period_balance:

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -597,6 +597,72 @@ def test_generate_planning_paid_leave_hours_balancing_regression():
     assert "info" not in result
 
 
+def test_generate_planning_allows_agent_with_full_period_leave_to_have_no_shift():
+    """
+    Agents fully blocked by leave should not make the model infeasible merely
+    because they receive no worked assignment on the generated period.
+    """
+
+    agents = [
+        {
+            "name": "Agent1",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [{"start": "05-01-2026", "end": "09-01-2026"}],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Agent2",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+    ]
+    vacations = ["Jour"]
+    week_schedule = [
+        "Lun. 05-01",
+        "Mar. 06-01",
+        "Mer. 07-01",
+        "Jeu. 08-01",
+        "Ven. 09-01",
+    ]
+
+    result = generate_planning(
+        agents,
+        vacations,
+        week_schedule,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={},
+        planning_start_date="2026-01-05",
+        runtime_config={
+            "vacation_durations": {"Jour": 12, "Conge": 7},
+            "staffing_requirements": {"Jour": 1},
+            "holidays": [],
+            "solver": {
+                "max_time_seconds": 30,
+                "relative_gap_limit": 0.1,
+                "num_search_workers": 0,
+                "global_max_gap": 600,
+                "period_max_gap": 600,
+                "max_weekly_hours": 60,
+                "optimize_period_balance": False,
+                "period_balance_weight": 2,
+                "min_free_weekends_per_horizon": 0,
+            },
+        },
+    )
+
+    assert "info" not in result
+    assert result["Agent1"] == []
+    assert len(result["Agent2"]) == len(week_schedule)
+
+
 def test_generate_planning_ignores_leave_periods_from_other_years():
     """
     Regression test: leave periods from another year must not block a target planning year.

--- a/backend/tests/test_half_vacations.py
+++ b/backend/tests/test_half_vacations.py
@@ -1,5 +1,7 @@
+from copy import deepcopy
+
 from app import get_week_schedule, validate_runtime_config
-from solver.catalog import build_vacation_catalog
+from solver.catalog import assignment_matches_choice, build_vacation_catalog
 from solver.engine import generate_planning
 
 
@@ -124,3 +126,155 @@ def test_half_vacations_are_forbidden_on_weekends():
     )
 
     assert "info" in result
+
+
+def test_solver_chooses_half_vacations_when_full_shift_exceeds_weekly_hours():
+    config = _runtime_config()
+    config["solver"]["max_weekly_hours"] = 6
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-05")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={},
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" not in result
+    assignments = [vacation for shifts in result.values() for _, vacation in shifts]
+    assert sorted(assignments) == ["Jour après-midi", "Jour matin"]
+
+
+def test_half_night_requires_next_day_rest():
+    config = _runtime_config()
+    config["agents"] = [_agent(f"Agent{i}", preferred=["Jour", "Nuit"]) for i in range(1, 5)]
+    config["vacations"] = ["Jour", "Nuit"]
+    config["staffing_requirements"] = {"Jour": 1, "Nuit": 1}
+    config["vacation_durations"] = {"Jour": 12, "Nuit": 12, "Conge": 7}
+    config["half_vacations"] = {
+        "Nuit": {
+            "enabled": True,
+            "penalty": 700,
+            "segments": [
+                {
+                    "name": "Nuit début",
+                    "label": "N début",
+                    "duration": 6,
+                    "is_night": True,
+                    "requires_next_day_rest": True,
+                },
+                {
+                    "name": "Nuit fin",
+                    "label": "N fin",
+                    "duration": 6,
+                    "is_night": True,
+                    "requires_next_day_rest": True,
+                },
+            ],
+        }
+    }
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-06")
+
+    feasible_result = generate_planning(
+        agents=config["agents"],
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in config["agents"]},
+        previous_week_schedule=[],
+        initial_shifts={"Agent1": [(week_schedule[0], "Nuit début")]},
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+    blocked_result = generate_planning(
+        agents=config["agents"],
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in config["agents"]},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Nuit début"), (week_schedule[1], "Jour")]
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" not in feasible_result
+    assert "info" in blocked_result
+
+
+def test_half_vacations_are_forbidden_on_holidays():
+    config = _runtime_config()
+    config["holidays"] = ["05-01"]
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-05")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" in result
+
+
+def test_parent_restriction_blocks_half_vacation_segments():
+    config = _runtime_config()
+    config["agents"][0]["restriction"] = ["Jour"]
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-05")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" in result
+
+
+def test_avoid_parent_inherits_and_segment_avoid_is_targeted():
+    config = _runtime_config()
+    catalog = build_vacation_catalog(config)
+
+    assert assignment_matches_choice(catalog, "Jour matin", {"Jour"})
+    assert assignment_matches_choice(catalog, "Jour matin", {"Jour matin"})
+    assert not assignment_matches_choice(catalog, "Jour après-midi", {"Jour matin"})
+
+
+def test_config_rejects_cdp_half_vacations():
+    config = deepcopy(_runtime_config())
+    config["vacations"] = ["Jour", "CDP"]
+    config["vacation_durations"]["CDP"] = 5.5
+    config["half_vacations"]["CDP"] = {
+        "enabled": True,
+        "penalty": 1000,
+        "segments": [
+            {"name": "CDP matin", "duration": 2.75},
+            {"name": "CDP après-midi", "duration": 2.75},
+        ],
+    }
+
+    errors = validate_runtime_config(config)
+
+    assert any(error["path"] == "half_vacations/CDP" for error in errors)

--- a/backend/tests/test_half_vacations.py
+++ b/backend/tests/test_half_vacations.py
@@ -1,0 +1,126 @@
+from app import get_week_schedule, validate_runtime_config
+from solver.catalog import build_vacation_catalog
+from solver.engine import generate_planning
+
+
+def _agent(name, preferred=None, restriction=None, unavailable=None):
+    return {
+        "name": name,
+        "preferences": {"preferred": preferred or ["Jour"], "avoid": []},
+        "restriction": restriction or [],
+        "unavailable": unavailable or [],
+        "training": [],
+        "exclusion": [],
+        "vacations": [],
+    }
+
+
+def _runtime_config():
+    return {
+        "agents": [
+            _agent("Agent1"),
+            _agent("Agent2"),
+        ],
+        "vacations": ["Jour"],
+        "staffing_requirements": {"Jour": 1},
+        "vacation_durations": {"Jour": 12, "Conge": 7},
+        "half_vacations": {
+            "Jour": {
+                "enabled": True,
+                "penalty": 500,
+                "segments": [
+                    {"name": "Jour matin", "label": "J matin", "duration": 6},
+                    {"name": "Jour après-midi", "label": "J aprem", "duration": 6},
+                ],
+            }
+        },
+        "vacation_colors": {
+            "Jour": "#75FA79",
+            "Jour matin": "#B9F6CA",
+            "Jour après-midi": "#00C853",
+        },
+        "holidays": [],
+        "solver": {
+            "max_time_seconds": 30,
+            "relative_gap_limit": 0.1,
+            "num_search_workers": 0,
+            "global_max_gap": 240,
+            "period_max_gap": 240,
+            "max_weekly_hours": 42,
+            "optimize_period_balance": False,
+            "period_balance_weight": 2,
+            "min_free_weekends_per_horizon": 0,
+        },
+    }
+
+
+def test_half_vacation_config_validates_and_builds_assignable_catalog():
+    config = _runtime_config()
+
+    assert validate_runtime_config(config) == []
+    catalog = build_vacation_catalog(config)
+
+    assert catalog["coverage_vacations"] == ["Jour"]
+    assert catalog["assignable_vacations"] == ["Jour", "Jour matin", "Jour après-midi"]
+    assert catalog["assignment_metadata"]["Jour matin"].parent == "Jour"
+    assert catalog["assignment_metadata"]["Jour matin"].duration == 60
+    assert catalog["segment_covering_assignments"][("Jour", "Jour matin")] == [
+        "Jour",
+        "Jour matin",
+    ]
+
+
+def test_half_vacation_config_rejects_duration_mismatch():
+    config = _runtime_config()
+    config["half_vacations"]["Jour"]["segments"][1]["duration"] = 5
+
+    errors = validate_runtime_config(config)
+
+    assert errors
+    assert "segment durations must sum" in errors[0]["message"]
+
+
+def test_solver_can_cover_parent_with_complementary_half_vacations():
+    config = _runtime_config()
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-05", "2026-01-05")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-05",
+    )
+
+    assert "info" not in result
+    assignments = [vacation for shifts in result.values() for _, vacation in shifts]
+    assert sorted(assignments) == ["Jour après-midi", "Jour matin"]
+
+
+def test_half_vacations_are_forbidden_on_weekends():
+    config = _runtime_config()
+    agents = config["agents"]
+    week_schedule = get_week_schedule("2026-01-10", "2026-01-10")
+
+    result = generate_planning(
+        agents=agents,
+        vacations=config["vacations"],
+        week_schedule=week_schedule,
+        dayOff={agent["name"]: [] for agent in agents},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [(week_schedule[0], "Jour matin")],
+            "Agent2": [(week_schedule[0], "Jour après-midi")],
+        },
+        runtime_config=config,
+        planning_start_date="2026-01-10",
+    )
+
+    assert "info" in result

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -262,6 +262,7 @@ def test_generate_planning_route_valid_data(client):
     assert response.status_code == 200
     result = response.get_json()
     assert "planning" in result
+    assert result["assignment_labels"]["Jour"] == "Jour"
     assert len(result["week_schedule"]) == 2
 
 
@@ -722,6 +723,59 @@ def test_optimize_existing_planning_keeps_multiple_manual_shifts(client):
     assert ["Lun. 05-01", vacations[0]] in payload["planning"][agent_a]
     assert ["Lun. 05-01", vacations[1]] in payload["planning"][agent_b]
     assert payload["meta"]["manual_cell_count"] == 2
+
+
+def test_optimize_existing_planning_reports_modified_existing_assignment(client):
+    config = deepcopy(load_default_config())
+    config["vacations"] = ["Jour", "Nuit"]
+    config["staffing_requirements"] = {"Jour": 1, "Nuit": 1}
+    config["vacation_durations"] = {"Jour": 12, "Nuit": 12, "Conge": 7}
+    config["half_vacations"] = {}
+    agent_name = config["agents"][0]["name"]
+    set_active_config(config)
+    data = {
+        "start_date": "2026-01-05",
+        "end_date": "2026-01-05",
+        "manual_entries": [
+            {
+                "agent": agent_name,
+                "date": "2026-01-05",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            }
+        ],
+    }
+    fake_result = {
+        "planning": {agent_name: [["Lun. 05-01", "Nuit"]]},
+        "vacation_durations": {"Jour": 12, "Nuit": 12, "Conge": 7},
+        "vacation_colors": {},
+        "assignable_vacations": ["Jour", "Nuit"],
+        "assignment_labels": {"Jour": "Jour", "Nuit": "Nuit"},
+        "week_schedule": ["Lun. 05-01"],
+        "holidays": [],
+        "unavailable": {},
+        "dayOff": {},
+        "training": {},
+        "restrictions": {},
+        "restriction_types_durations": {},
+    }
+    with patch("app._build_planning_payload", return_value=(fake_result, 200)):
+        response = client.post(
+            "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+        )
+
+    payload = response.get_json()
+    assert payload["modified_existing_assignments"] == [
+        {
+            "agent": agent_name,
+            "date": "2026-01-05",
+            "day": "Lun. 05-01",
+            "initial_value": "Jour",
+            "final_value": "Nuit",
+            "change_type": "changed_to_full",
+        }
+    ]
 
 
 def test_inject_manual_status_entries_adds_unavailable_day():

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -407,7 +407,7 @@ def test_diagnose_manual_entry_conflicts_detects_understaffed_shift_capacity():
     staffing_reason = next(
         reason for reason in reasons if reason["code"] == "STAFFING_REQUIREMENT_UNMET"
     )
-    assert staffing_reason["count"] == 1
+    assert staffing_reason["count"] == 2
     assert "2026-01-15 / Jour" in staffing_reason["details"][0]
 
 
@@ -446,9 +446,10 @@ def test_diagnose_manual_entry_conflicts_detects_manual_overstaffing():
     assert "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT" in reason_codes
 
 
-def test_diagnose_manual_entry_conflicts_detects_day_shift_weekly_limit():
+def test_diagnose_manual_entry_conflicts_does_not_emit_day_shift_weekly_quota():
     config = deepcopy(load_default_config())
     agent_name = config["agents"][0]["name"]
+    config["solver"]["max_weekly_hours"] = 48
     entries = [
         {
             "agent": agent_name,
@@ -462,14 +463,8 @@ def test_diagnose_manual_entry_conflicts_detects_day_shift_weekly_limit():
 
     reasons = _diagnose_manual_entry_conflicts(entries, config)
 
-    weekly_limit_reason = next(
-        reason
-        for reason in reasons
-        if reason["code"] == "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED"
-    )
-    assert weekly_limit_reason["count"] == 1
-    assert "4 vacations Jour" in weekly_limit_reason["details"][0]
-
+    reason_codes = [reason["code"] for reason in reasons]
+    assert "MANUAL_DAY_SHIFT_WEEKLY_LIMIT_EXCEEDED" not in reason_codes
 
 def test_diagnose_manual_entry_conflicts_detects_shift_after_night():
     config = deepcopy(load_default_config())

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -4,6 +4,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 from app import (
+    RELAXED_CONSTRAINT_DIAGNOSTICS,
     _diagnose_manual_entry_conflicts,
     _probe_relaxed_hard_constraints,
     _inject_manual_status_entries,
@@ -522,6 +523,12 @@ def test_probe_relaxed_hard_constraints_reports_feasible_relaxed_constraint():
 
     assert reasons[0]["code"] == "RELAXED_CONSTRAINT_MAKES_FEASIBLE"
     assert "couverture quotidienne" in reasons[0]["message"]
+
+
+def test_relaxed_constraints_do_not_include_agent_minimum_assignment():
+    constraints = [diagnostic["constraint"] for diagnostic in RELAXED_CONSTRAINT_DIAGNOSTICS]
+
+    assert "require_at_least_one_shift_per_agent" not in constraints
 
 
 def test_probe_relaxed_hard_constraints_uses_generic_rest_wording():

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -410,6 +410,12 @@ def test_diagnose_manual_entry_conflicts_detects_understaffed_shift_capacity():
     )
     assert staffing_reason["count"] == 2
     assert "2026-01-15 / Jour" in staffing_reason["details"][0]
+    assert staffing_reason["segments"][0]["date"] == "2026-01-15"
+    assert staffing_reason["segments"][0]["vacation"] == "Jour"
+    assert staffing_reason["segments"][0]["required_agents"] == 2
+    assert staffing_reason["segments"][0]["eligible_agents"] == 0
+    assert "status" in staffing_reason["segments"][0]["blockers"]
+    assert "free_agent" in staffing_reason["segments"][0]["actions"]
 
 
 def test_diagnose_manual_entry_conflicts_detects_manual_overstaffing():
@@ -516,6 +522,30 @@ def test_probe_relaxed_hard_constraints_reports_feasible_relaxed_constraint():
 
     assert reasons[0]["code"] == "RELAXED_CONSTRAINT_MAKES_FEASIBLE"
     assert "couverture quotidienne" in reasons[0]["message"]
+
+
+def test_probe_relaxed_hard_constraints_uses_generic_rest_wording():
+    config = deepcopy(load_default_config())
+
+    def fake_build(payload, runtime_config):
+        disabled = runtime_config.get("_disabled_hard_constraints_for_diagnostics", [])
+        if disabled == ["avoid_day_after_night"]:
+            return {"planning": {}}, 200
+        return {"info": "No solution found."}, 400
+
+    with patch("app._build_planning_payload", side_effect=fake_build):
+        reasons = _probe_relaxed_hard_constraints(
+            {
+                "start_date": "2026-01-15",
+                "end_date": "2026-01-15",
+                "initial_shifts": {},
+            },
+            config,
+        )
+
+    assert reasons[0]["code"] == "RELAXED_CONSTRAINT_MAKES_FEASIBLE"
+    assert "repos après affectation de nuit" in reasons[0]["message"]
+    assert "Nuit" not in reasons[0]["message"]
 
 
 def test_optimize_existing_planning_unsat_uses_relaxed_constraint_diagnostics(client):

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -51,6 +51,8 @@ Allowed shift names:
 - Notes:
   - Shift names are now dynamic (`"Soutien"`, `"Renfort"`, etc. are allowed).
   - The solver uses this list as the source of truth for generated shift types.
+  - `CDP` keeps a historical hard limit of 2 assignments per agent and per week.
+    Other workload limits are hour-based through `solver.max_weekly_hours`.
 
 ### `staffing_requirements` (optional)
 
@@ -68,6 +70,12 @@ Allowed shift names:
 - Required for each configured vacation:
   - Every value in `vacations` must have a matching key in `vacation_durations`.
 - Purpose: paid-hour durations used by balancing constraints.
+
+### `half_vacations` (optional)
+
+- Type: object keyed by parent vacation name.
+- Purpose: define assignable segments that can cover a parent vacation segment by segment.
+- `CDP` is intentionally not splittable; `half_vacations.CDP` is rejected at runtime.
 
 ### `holidays` (required)
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -75,7 +75,108 @@ Allowed shift names:
 
 - Type: object keyed by parent vacation name.
 - Purpose: define assignable segments that can cover a parent vacation segment by segment.
+- A parent vacation remains assignable as a full vacation.
+- Each segment is also assignable when its parent is enabled.
+- Daily coverage is checked segment by segment:
+  - a full parent assignment covers every segment;
+  - a segment assignment covers only its matching segment.
+- `staffing_requirements[parent] = N` means each segment of that parent must be covered `N` times.
+- Half-vacations are rejected on weekends and recurring holidays.
 - `CDP` is intentionally not splittable; `half_vacations.CDP` is rejected at runtime.
+
+Example:
+
+```json
+"half_vacations": {
+  "Jour": {
+    "enabled": true,
+    "penalty": 500,
+    "segments": [
+      {
+        "name": "Jour matin",
+        "label": "J matin",
+        "duration": 6
+      },
+      {
+        "name": "Jour apres-midi",
+        "label": "J aprem",
+        "duration": 6
+      }
+    ]
+  },
+  "Nuit": {
+    "enabled": true,
+    "penalty": 700,
+    "segments": [
+      {
+        "name": "Nuit debut",
+        "label": "N debut",
+        "duration": 6,
+        "is_night": true,
+        "requires_next_day_rest": true
+      },
+      {
+        "name": "Nuit fin",
+        "label": "N fin",
+        "duration": 6,
+        "is_night": true,
+        "requires_next_day_rest": true
+      }
+    ]
+  }
+}
+```
+
+Validation rules:
+
+- `segments` must contain at least two valid entries.
+- segment names must be unique across all assignable vacations.
+- each segment duration must be positive.
+- segment durations must sum to the parent duration in `vacation_durations`.
+- `penalty` is a soft objective penalty: higher values make half-vacations less preferred without making them impossible.
+
+### `vacation_colors` (optional)
+
+- Type: object of `{ "<assignable_vacation_name>": "#RRGGBB" }`
+- Purpose: frontend display colors for full vacations and half-vacation segments.
+- Colors must be six-digit hex values.
+- Parent vacation colors are recommended.
+- Segment colors are optional but recommended for readability.
+- The frontend configuration editor saves colors only for active vacations and saved segments.
+
+Example:
+
+```json
+"vacation_colors": {
+  "Jour": "#75FA79",
+  "Jour matin": "#B9F6CA",
+  "Jour apres-midi": "#00C853",
+  "Nuit": "#9175FA"
+}
+```
+
+### `vacation_metadata` (optional)
+
+- Type: object keyed by parent vacation name.
+- Purpose: override labels and night/rest behavior for full parent vacations.
+
+Example:
+
+```json
+"vacation_metadata": {
+  "Nuit": {
+    "label": "N",
+    "is_night": true,
+    "requires_next_day_rest": true
+  }
+}
+```
+
+Notes:
+
+- `is_night` marks an assignment as a night assignment for night-specific safety rules.
+- `requires_next_day_rest` blocks non-night work on the following day.
+- Segment-level metadata in `half_vacations[].segments[]` overrides or inherits from the parent behavior.
 
 ### `holidays` (required)
 
@@ -108,6 +209,10 @@ Supported keys:
 - Using `YYYY-mm-dd` instead of `dd-mm-YYYY` in agent dates.
 - Adding comments inside JSON (JSON does not support comments).
 - Defining a shift in `vacations` without matching duration in `vacation_durations`.
+- Defining `half_vacations.CDP` (CDP is not splittable).
+- Defining half-vacation segment durations that do not sum to the parent duration.
+- Reusing a segment name that already exists as another vacation or segment.
+- Forgetting colors for newly added segments, making the planning harder to read.
 - Setting a negative staffing value (must be integer `>= 0`).
 - Forgetting required agent keys (all agent fields are expected, use empty arrays if needed).
 - Setting solver keys with wrong types (for example `"0.1"` as a string).

--- a/docs/optimization-existing-schedule-mvp.md
+++ b/docs/optimization-existing-schedule-mvp.md
@@ -1,5 +1,16 @@
 # Optimization of Existing Schedule — MVP Technical Spec
 
+## Status Note
+
+This document describes the original MVP target. The implemented feature has since evolved:
+
+- manual shift entries are now treated as existing assignments to preserve when possible, not hard locks;
+- status entries still inject hard non-working constraints;
+- backend responses include structured blocking reasons, segment-level diagnostics, impacted cells, suggestions, and modified existing assignments;
+- the frontend displays warnings, suggestions, blocking reasons, structured diagnostic segments, and existing assignments modified by the optimizer.
+
+Use this document as historical implementation context. For current API/config behavior, also see `docs/config-reference.md` and the route tests in `backend/tests/test_routes.py`.
+
 ## 1) Goal
 
 Add a third planning mode that lets users:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -172,7 +172,7 @@
                 <select v-model="selectedShifts[agent.name][day]">
                   <option value="">-</option>
                   <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
-                    {{ vacation }}
+                    {{ getAssignmentLabel(vacation) }}
                   </option>
                 </select>
               </td>
@@ -204,7 +204,7 @@
                   <select v-model="manualSelectedShifts[agent.name][day]">
                     <option value="">-</option>
                     <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
-                      {{ vacation }}
+                      {{ getAssignmentLabel(vacation) }}
                     </option>
                     <option value="status:unavailable">Indisponible</option>
                     <option value="status:training">Formation</option>
@@ -279,6 +279,23 @@
         </ul>
       </div>
 
+      <div v-if="isExistingOptimizationMode && optimizationModifiedAssignments.length" class="info-card">
+        <span class="info-icon">i</span>
+        <div>
+          <strong>Affectations existantes modifiées</strong>
+          <ul class="modified-list">
+            <li
+              v-for="(modification, index) in optimizationModifiedAssignments"
+              :key="`mod_${index}`"
+            >
+              {{ modification.agent }} - {{ modification.date || modification.day }} :
+              {{ getAssignmentLabel(modification.initial_value) }} -> {{ getAssignmentLabel(modification.final_value) || 'cellule vidée' }}
+              ({{ formatModificationType(modification.change_type) }})
+            </li>
+          </ul>
+        </div>
+      </div>
+
       <div>
         <button @click="generatePlanning" :disabled="isLoading || isConfigSaving">
           {{ isLoading ? "Génération en cours..." : actionButtonLabel }}
@@ -301,7 +318,8 @@
           :dayOff="dayOffFromConfig"
           :training="trainingFromConfig"
           :restrictions="restrictionsFromConfig"
-          :restrictionsDurations="restrictionDurationsFromConfig"
+          :restrictionDurations="restrictionDurationsFromConfig"
+          :assignmentLabels="assignmentLabels"
           :planningStartDate="startDate"
         />
       </div>
@@ -370,6 +388,7 @@ export default {
       endDate: null,
       planningResult: null,
       vacationDurations: null,
+      assignmentLabels: {},
       weekSchedule: [],
       vacationColors: {
         Jour: '#75FA79',
@@ -396,6 +415,7 @@ export default {
       optimizationSuggestions: [],
       optimizationBlockingReasons: [],
       optimizationImpactedCells: [],
+      optimizationModifiedAssignments: [],
       optimizationMeta: null,
       optimizationStatus: null,
       isLoading: false,
@@ -509,6 +529,7 @@ export default {
     resetPlanningData() {
       this.planningResult = null;
       this.vacationDurations = null;
+      this.assignmentLabels = {};
       this.weekSchedule = [];
       this.holidaysFromConfig = [];
       this.unavailableFromConfig = null;
@@ -522,6 +543,7 @@ export default {
       this.optimizationStatus = null;
       this.optimizationBlockingReasons = [];
       this.optimizationImpactedCells = [];
+      this.optimizationModifiedAssignments = [];
     },
     async applyConfigToState(config) {
       this.isHydratingConfig = true;
@@ -701,6 +723,18 @@ export default {
       });
       this.assignableVacationsData = this.buildAssignableVacations(this.configData);
     },
+    getAssignmentLabel(assignment) {
+      if (!assignment) return '';
+      return this.assignmentLabels?.[assignment] || assignment;
+    },
+    formatModificationType(changeType) {
+      const labels = {
+        changed_to_full: 'remplacée par vacation complète',
+        changed_to_half: 'remplacée par demi-vacation',
+        cleared: 'vidée'
+      };
+      return labels[changeType] || changeType || 'modifiée';
+    },
     setVacationDuration(vacation, value) {
       const parsed = Number(value);
       this.configData.vacation_durations[vacation] = Number.isFinite(parsed) ? parsed : 1;
@@ -858,6 +892,7 @@ export default {
         const response = await apiPost(endpoint, payload);
         this.planningResult = response.data.planning;
         this.vacationDurations = response.data.vacation_durations;
+        this.assignmentLabels = response.data.assignment_labels || {};
         this.vacationColors = { ...this.vacationColors, ...(response.data.vacation_colors || {}) };
         this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.weekSchedule = response.data.week_schedule;
@@ -871,6 +906,7 @@ export default {
         this.optimizationSuggestions = response.data.suggestions || [];
         this.optimizationBlockingReasons = response.data.blocking_reasons || [];
         this.optimizationImpactedCells = response.data.impacted_cells || [];
+        this.optimizationModifiedAssignments = response.data.modified_existing_assignments || [];
         this.optimizationMeta = response.data.meta || null;
         this.optimizationStatus = response.data.status || null;
       } catch (error) {
@@ -881,6 +917,7 @@ export default {
           this.optimizationSuggestions = responseData.suggestions || [];
           this.optimizationBlockingReasons = responseData.blocking_reasons || [];
           this.optimizationImpactedCells = responseData.impacted_cells || [];
+          this.optimizationModifiedAssignments = responseData.modified_existing_assignments || [];
           this.optimizationMeta = responseData.meta || null;
           this.infoMessage = responseData.error || "Aucune solution trouvée. Consultez les suggestions.";
         } else if (responseData?.info) {
@@ -1112,6 +1149,11 @@ button:disabled {
   color: #8a0000;
   font-size: 14px;
   margin-top: 4px;
+}
+
+.modified-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
 }
 
 .info-card {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -171,7 +171,7 @@
               >
                 <select v-model="selectedShifts[agent.name][day]">
                   <option value="">-</option>
-                  <option v-for="vacation in vacations" :key="vacation" :value="vacation">
+                  <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
                     {{ vacation }}
                   </option>
                 </select>
@@ -203,7 +203,7 @@
                 >
                   <select v-model="manualSelectedShifts[agent.name][day]">
                     <option value="">-</option>
-                    <option v-for="vacation in vacations" :key="vacation" :value="vacation">
+                    <option v-for="vacation in assignableVacations" :key="vacation" :value="vacation">
                       {{ vacation }}
                     </option>
                     <option value="status:unavailable">Indisponible</option>
@@ -388,6 +388,7 @@ export default {
       previousWeekSchedule: [],
       agents: [],
       vacations: ['Jour', 'Nuit', 'CDP'],
+      assignableVacationsData: ['Jour', 'Nuit', 'CDP'],
       selectedShifts: {},
       manualWeekSchedule: [],
       manualSelectedShifts: {},
@@ -415,6 +416,12 @@ export default {
           Jour: 1,
           Nuit: 1,
           CDP: 1
+        },
+        half_vacations: {},
+        vacation_colors: {
+          Jour: '#75FA79',
+          Nuit: '#9175FA',
+          CDP: '#A59384'
         },
         holidays: [],
         solver: {}
@@ -473,12 +480,31 @@ export default {
     },
     restrictionTypesDurations() {
       return this.restrictionDurationsFromConfig || this.configData?.restriction_types_durations || {};
+    },
+    assignableVacations() {
+      return this.assignableVacationsData?.length ? this.assignableVacationsData : this.vacations;
     }
   },
   methods: {
     resetMessages() {
       this.errorMessage = null;
       this.infoMessage = null;
+    },
+
+    buildAssignableVacations(config) {
+      const assignable = [...(config?.vacations || [])];
+      const seen = new Set(assignable);
+      Object.entries(config?.half_vacations || {}).forEach(([parent, halfConfig]) => {
+        if (!seen.has(parent) || halfConfig?.enabled === false) return;
+        (halfConfig.segments || []).forEach((segment) => {
+          const name = segment?.name;
+          if (name && !seen.has(name)) {
+            seen.add(name);
+            assignable.push(name);
+          }
+        });
+      });
+      return assignable;
     },
     resetPlanningData() {
       this.planningResult = null;
@@ -507,6 +533,8 @@ export default {
       normalized.holidays = Array.isArray(normalized.holidays) ? normalized.holidays : [];
       normalized.solver = normalized.solver || {};
       normalized.restriction_types_durations = normalized.restriction_types_durations || {};
+      normalized.half_vacations = normalized.half_vacations || {};
+      normalized.vacation_colors = normalized.vacation_colors || {};
 
       normalized.vacations = normalized.vacations.map((value) => String(value).trim()).filter(Boolean);
       normalized.vacations.forEach((vacation) => {
@@ -540,6 +568,8 @@ export default {
       this.vacationsInput = normalized.vacations.join(', ');
       this.holidaysInput = normalized.holidays.join(', ');
       this.vacations = [...normalized.vacations];
+      this.assignableVacationsData = this.buildAssignableVacations(normalized);
+      this.vacationColors = { ...this.vacationColors, ...normalized.vacation_colors };
       this.agents = [...normalized.agents];
       this.restrictionDurationsFromConfig = normalized.restriction_types_durations;
       await this.$nextTick();
@@ -578,6 +608,8 @@ export default {
 
       payload.vacation_durations = payload.vacation_durations || {};
       payload.staffing_requirements = payload.staffing_requirements || {};
+      payload.half_vacations = payload.half_vacations || {};
+      payload.vacation_colors = payload.vacation_colors || {};
 
       payload.vacations.forEach((vacation) => {
         const duration = Number(payload.vacation_durations[vacation]);
@@ -663,7 +695,11 @@ export default {
         if (this.configData.staffing_requirements[vacation] == null) {
           this.configData.staffing_requirements[vacation] = 1;
         }
+        if (this.configData.vacation_colors?.[vacation] == null) {
+          this.configData.vacation_colors[vacation] = this.vacationColors[vacation] || '#ffffff';
+        }
       });
+      this.assignableVacationsData = this.buildAssignableVacations(this.configData);
     },
     setVacationDuration(vacation, value) {
       const parsed = Number(value);
@@ -723,6 +759,7 @@ export default {
         });
         this.previousWeekSchedule = response.data.previous_week_schedule;
         this.agents = response.data.agents || [];
+        this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.selectedShifts = {};
         this.agents.forEach((agent) => {
           if (!agent.name) {
@@ -821,6 +858,8 @@ export default {
         const response = await apiPost(endpoint, payload);
         this.planningResult = response.data.planning;
         this.vacationDurations = response.data.vacation_durations;
+        this.vacationColors = { ...this.vacationColors, ...(response.data.vacation_colors || {}) };
+        this.assignableVacationsData = response.data.assignable_vacations || this.assignableVacationsData;
         this.weekSchedule = response.data.week_schedule;
         this.holidaysFromConfig = response.data.holidays;
         this.unavailableFromConfig = response.data.unavailable;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -771,6 +771,7 @@ export default {
       }
 
       payload.half_vacations = this.buildHalfVacationsPayload(payload);
+      payload.vacation_colors = this.buildVacationColorsPayload(payload);
 
       payload.agents = (payload.agents || []).map((agent, index) => ({
         ...defaultAgent(`Agent${index + 1}`),
@@ -825,6 +826,21 @@ export default {
         };
       });
       return halfVacations;
+    },
+    buildVacationColorsPayload(payload) {
+      const allowedNames = new Set(payload.vacations || []);
+      Object.values(payload.half_vacations || {}).forEach((halfConfig) => {
+        (halfConfig.segments || []).forEach((segment) => {
+          allowedNames.add(segment.name);
+        });
+      });
+      const colors = {};
+      Object.entries(payload.vacation_colors || {}).forEach(([vacation, color]) => {
+        if (allowedNames.has(vacation) && /^#[0-9A-Fa-f]{6}$/.test(color)) {
+          colors[vacation] = color;
+        }
+      });
+      return colors;
     },
     formatValidationErrors(details) {
       if (!Array.isArray(details) || details.length === 0) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -352,6 +352,40 @@
                   {{ detail }}
                 </li>
               </ul>
+              <div v-if="reason.segments?.length" class="diagnostic-segments">
+                <div
+                  v-for="(segment, segmentIndex) in reason.segments"
+                  :key="`reason_${index}_segment_${segmentIndex}`"
+                  class="diagnostic-segment"
+                >
+                  <strong>
+                    {{ segment.date }} / {{ segment.vacation }} / {{ segment.segment }}
+                  </strong>
+                  <span v-if="segment.required_agents != null">
+                    Besoin: {{ segment.required_agents }}
+                  </span>
+                  <span v-if="segment.eligible_agents != null">
+                    Agents possibles: {{ segment.eligible_agents }}
+                  </span>
+                  <span v-if="segment.manual_count != null">
+                    Saisies: {{ segment.manual_count }}
+                  </span>
+                  <p v-if="formatBlockers(segment.blockers)" class="diagnostic-line">
+                    Blocages: {{ formatBlockers(segment.blockers) }}
+                  </p>
+                  <p v-if="formatActions(segment.actions)" class="diagnostic-line">
+                    Actions: {{ formatActions(segment.actions) }}
+                  </p>
+                  <ul v-if="segment.sample_blocked_agents?.length" class="blocked-agents">
+                    <li
+                      v-for="(blockedAgent, blockedIndex) in segment.sample_blocked_agents"
+                      :key="`reason_${index}_segment_${segmentIndex}_agent_${blockedIndex}`"
+                    >
+                      {{ blockedAgent.agent }}: {{ formatReasonCodes(blockedAgent.reasons) }}
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </li>
           </ul>
           <p v-if="optimizationImpactedCells.length">
@@ -1018,6 +1052,44 @@ export default {
       };
       return labels[changeType] || changeType || 'modifiée';
     },
+    formatBlockerCode(code) {
+      const labels = {
+        existing_assignment: 'affectation existante differente',
+        status: 'statut bloquant',
+        restriction: 'restriction directe',
+        parent_restriction: 'restriction parent',
+        half_weekend: 'demi-vacation interdite week-end',
+        half_holiday: 'demi-vacation interdite jour ferie'
+      };
+      return labels[code] || code;
+    },
+    formatActionCode(code) {
+      const labels = {
+        clear_cell: 'vider une cellule',
+        reduce_existing_assignment_count: 'reduire les saisies existantes',
+        free_agent: 'liberer un agent',
+        increase_max_weekly_hours: 'augmenter le plafond horaire',
+        reduce_staffing_requirement: 'reduire le besoin de couverture',
+        use_full_vacation: 'utiliser une vacation complete',
+        allow_or_assign_half_vacations: 'autoriser ou assigner des demi-vacations'
+      };
+      return labels[code] || code;
+    },
+    formatBlockers(blockers) {
+      if (!blockers || typeof blockers !== 'object') return '';
+      return Object.entries(blockers)
+        .filter(([, count]) => count)
+        .map(([code, count]) => `${this.formatBlockerCode(code)} (${count})`)
+        .join(', ');
+    },
+    formatActions(actions) {
+      if (!Array.isArray(actions) || actions.length === 0) return '';
+      return actions.map((action) => this.formatActionCode(action)).join(', ');
+    },
+    formatReasonCodes(reasons) {
+      if (!Array.isArray(reasons) || reasons.length === 0) return 'blocage non precise';
+      return reasons.map((reason) => this.formatBlockerCode(reason)).join(', ');
+    },
     setVacationDuration(vacation, value) {
       const parsed = Number(value);
       this.configData.vacation_durations[vacation] = Number.isFinite(parsed) ? parsed : 1;
@@ -1494,6 +1566,33 @@ button:disabled {
   color: #8a0000;
   font-size: 14px;
   margin-top: 4px;
+}
+
+.diagnostic-segments {
+  margin-top: 8px;
+}
+
+.diagnostic-segment {
+  background: #fffafa;
+  border: 1px solid #e6b4b4;
+  border-radius: 6px;
+  color: #690000;
+  margin-top: 8px;
+  padding: 8px;
+}
+
+.diagnostic-segment span {
+  display: inline-block;
+  margin-right: 12px;
+}
+
+.diagnostic-line {
+  margin: 6px 0 0;
+}
+
+.blocked-agents {
+  margin: 6px 0 0;
+  padding-left: 18px;
 }
 
 .modified-list {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -61,6 +61,103 @@
       </div>
 
       <div class="config-block">
+        <h3>Demi-vacations</h3>
+        <p v-if="hasCdpVacation" class="config-note">CDP n'est pas decoupable.</p>
+
+        <div v-for="parent in splittableVacations" :key="`half_${parent}`" class="half-vacation-card">
+          <div class="half-vacation-header">
+            <strong>{{ parent }}</strong>
+            <label class="inline-control">
+              <input
+                type="checkbox"
+                :checked="isHalfVacationEnabled(parent)"
+                @change="setHalfVacationEnabled(parent, $event.target.checked)"
+              />
+              Activer
+            </label>
+            <label>
+              Penalite
+              <input
+                type="number"
+                min="0"
+                step="1"
+                :disabled="!isHalfVacationEnabled(parent)"
+                :value="getHalfVacationConfig(parent).penalty"
+                @input="setHalfVacationPenalty(parent, $event.target.value)"
+              />
+            </label>
+            <button
+              class="secondary-btn"
+              :disabled="!isHalfVacationEnabled(parent)"
+              @click="addHalfVacationSegment(parent)"
+            >
+              Ajouter segment
+            </button>
+          </div>
+
+          <div v-if="isHalfVacationEnabled(parent)" class="half-segments">
+            <div
+              v-for="(segment, segmentIndex) in getHalfVacationConfig(parent).segments"
+              :key="`seg_${parent}_${segmentIndex}`"
+              class="half-segment-row"
+            >
+              <label>
+                Nom
+                <input
+                  type="text"
+                  :value="segment.name"
+                  @input="setHalfVacationSegmentField(parent, segmentIndex, 'name', $event.target.value)"
+                />
+              </label>
+              <label>
+                Label
+                <input
+                  type="text"
+                  :value="segment.label"
+                  @input="setHalfVacationSegmentField(parent, segmentIndex, 'label', $event.target.value)"
+                />
+              </label>
+              <label>
+                Duree
+                <input
+                  type="number"
+                  min="0.1"
+                  step="0.1"
+                  :value="segment.duration"
+                  @input="setHalfVacationSegmentField(parent, segmentIndex, 'duration', $event.target.value)"
+                />
+              </label>
+              <label>
+                Couleur
+                <input
+                  type="color"
+                  :value="getVacationColorValue(segment.name)"
+                  @input="setVacationColor(segment.name, $event.target.value)"
+                />
+              </label>
+              <label class="inline-control">
+                <input
+                  type="checkbox"
+                  :checked="Boolean(segment.is_night)"
+                  @change="setHalfVacationSegmentField(parent, segmentIndex, 'is_night', $event.target.checked)"
+                />
+                Nuit
+              </label>
+              <label class="inline-control">
+                <input
+                  type="checkbox"
+                  :checked="Boolean(segment.requires_next_day_rest)"
+                  @change="setHalfVacationSegmentField(parent, segmentIndex, 'requires_next_day_rest', $event.target.checked)"
+                />
+                Repos J+1
+              </label>
+              <button class="danger-btn compact-btn" @click="removeHalfVacationSegment(parent, segmentIndex)">X</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="config-block">
         <h3>Agents</h3>
         <button @click="addAgent">Ajouter un agent</button>
 
@@ -503,6 +600,12 @@ export default {
     },
     assignableVacations() {
       return this.assignableVacationsData?.length ? this.assignableVacationsData : this.vacations;
+    },
+    splittableVacations() {
+      return (this.configData.vacations || []).filter((vacation) => vacation !== 'CDP');
+    },
+    hasCdpVacation() {
+      return (this.configData.vacations || []).includes('CDP');
     }
   },
   methods: {
@@ -571,6 +674,26 @@ export default {
       if (normalized.vacation_durations.Conge == null) {
         normalized.vacation_durations.Conge = 7;
       }
+
+      Object.entries(normalized.half_vacations).forEach(([parent, halfConfig]) => {
+        if (parent === 'CDP' || !normalized.vacations.includes(parent)) {
+          delete normalized.half_vacations[parent];
+          return;
+        }
+        normalized.half_vacations[parent] = {
+          enabled: halfConfig?.enabled !== false,
+          penalty: Number.isFinite(Number(halfConfig?.penalty)) ? Number(halfConfig.penalty) : 500,
+          segments: Array.isArray(halfConfig?.segments)
+            ? halfConfig.segments.map((segment) => ({
+              name: segment?.name || '',
+              label: segment?.label || '',
+              duration: Number.isFinite(Number(segment?.duration)) ? Number(segment.duration) : 1,
+              is_night: Boolean(segment?.is_night),
+              requires_next_day_rest: Boolean(segment?.requires_next_day_rest)
+            }))
+            : []
+        };
+      });
 
       normalized.agents = normalized.agents.map((agent, index) => ({
         ...defaultAgent(`Agent${index + 1}`),
@@ -647,6 +770,8 @@ export default {
         payload.vacation_durations.Conge = Number(payload.vacation_durations.Conge);
       }
 
+      payload.half_vacations = this.buildHalfVacationsPayload(payload);
+
       payload.agents = (payload.agents || []).map((agent, index) => ({
         ...defaultAgent(`Agent${index + 1}`),
         ...agent,
@@ -668,6 +793,38 @@ export default {
       }));
 
       return payload;
+    },
+    buildHalfVacationsPayload(payload) {
+      const halfVacations = {};
+      Object.entries(payload.half_vacations || {}).forEach(([parent, halfConfig]) => {
+        if (parent === 'CDP' || !payload.vacations.includes(parent) || halfConfig?.enabled === false) {
+          return;
+        }
+        const segments = (halfConfig?.segments || [])
+          .map((segment) => {
+            const name = String(segment?.name || '').trim();
+            const label = String(segment?.label || '').trim();
+            const duration = Number(segment?.duration);
+            if (!name || !Number.isFinite(duration) || duration <= 0) {
+              return null;
+            }
+            const normalizedSegment = { name, duration };
+            if (label) normalizedSegment.label = label;
+            if (segment?.is_night) normalizedSegment.is_night = true;
+            if (segment?.requires_next_day_rest) normalizedSegment.requires_next_day_rest = true;
+            return normalizedSegment;
+          })
+          .filter(Boolean);
+        if (segments.length < 2) {
+          return;
+        }
+        halfVacations[parent] = {
+          enabled: true,
+          penalty: Math.max(0, Math.floor(Number(halfConfig?.penalty) || 0)),
+          segments
+        };
+      });
+      return halfVacations;
     },
     formatValidationErrors(details) {
       if (!Array.isArray(details) || details.length === 0) {
@@ -721,7 +878,117 @@ export default {
           this.configData.vacation_colors[vacation] = this.vacationColors[vacation] || '#ffffff';
         }
       });
+      Object.keys(this.configData.half_vacations || {}).forEach((parent) => {
+        if (!parsed.includes(parent) || parent === 'CDP') {
+          delete this.configData.half_vacations[parent];
+        }
+      });
       this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+    },
+    getHalfVacationConfig(parent) {
+      return this.configData.half_vacations?.[parent] || { enabled: false, penalty: 500, segments: [] };
+    },
+    isHalfVacationEnabled(parent) {
+      return this.configData.half_vacations?.[parent]?.enabled === true;
+    },
+    ensureHalfVacationConfig(parent) {
+      if (parent === 'CDP') return null;
+      if (!this.configData.half_vacations) {
+        this.configData.half_vacations = {};
+      }
+      if (!this.configData.half_vacations[parent]) {
+        const parentDuration = Number(this.configData.vacation_durations?.[parent]) || 2;
+        this.configData.half_vacations[parent] = {
+          enabled: true,
+          penalty: 500,
+          segments: [
+            {
+              name: `${parent} 1`,
+              label: `${parent} 1`,
+              duration: parentDuration / 2
+            },
+            {
+              name: `${parent} 2`,
+              label: `${parent} 2`,
+              duration: parentDuration / 2
+            }
+          ]
+        };
+      }
+      return this.configData.half_vacations[parent];
+    },
+    setHalfVacationEnabled(parent, enabled) {
+      if (!enabled) {
+        if (this.configData.half_vacations?.[parent]) {
+          this.configData.half_vacations[parent].enabled = false;
+        }
+        this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+        return;
+      }
+      const config = this.ensureHalfVacationConfig(parent);
+      if (config) {
+        config.enabled = true;
+      }
+      this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+    },
+    setHalfVacationPenalty(parent, value) {
+      const config = this.ensureHalfVacationConfig(parent);
+      if (!config) return;
+      const parsed = Math.floor(Number(value));
+      config.penalty = Number.isFinite(parsed) ? Math.max(parsed, 0) : 0;
+    },
+    addHalfVacationSegment(parent) {
+      const config = this.ensureHalfVacationConfig(parent);
+      if (!config) return;
+      config.segments.push({
+        name: `${parent} ${config.segments.length + 1}`,
+        label: `${parent} ${config.segments.length + 1}`,
+        duration: 1
+      });
+      this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+    },
+    removeHalfVacationSegment(parent, segmentIndex) {
+      const config = this.getHalfVacationConfig(parent);
+      if (!Array.isArray(config.segments)) return;
+      const [removed] = config.segments.splice(segmentIndex, 1);
+      if (removed?.name && this.configData.vacation_colors) {
+        delete this.configData.vacation_colors[removed.name];
+      }
+      this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+    },
+    setHalfVacationSegmentField(parent, segmentIndex, field, value) {
+      const config = this.ensureHalfVacationConfig(parent);
+      const segment = config?.segments?.[segmentIndex];
+      if (!segment) return;
+      const previousName = segment.name;
+      if (field === 'duration') {
+        const parsed = Number(value);
+        segment.duration = Number.isFinite(parsed) ? parsed : 1;
+      } else if (field === 'is_night' || field === 'requires_next_day_rest') {
+        segment[field] = Boolean(value);
+      } else {
+        segment[field] = value;
+      }
+      if (field === 'name' && previousName !== value) {
+        if (this.configData.vacation_colors?.[previousName] && !this.configData.vacation_colors?.[value]) {
+          this.configData.vacation_colors[value] = this.configData.vacation_colors[previousName];
+        }
+        if (this.configData.vacation_colors?.[previousName]) {
+          delete this.configData.vacation_colors[previousName];
+        }
+        this.assignableVacationsData = this.buildAssignableVacations(this.configData);
+      }
+    },
+    getVacationColorValue(vacation) {
+      return this.configData.vacation_colors?.[vacation] || '#ffffff';
+    },
+    setVacationColor(vacation, color) {
+      if (!vacation) return;
+      if (!this.configData.vacation_colors) {
+        this.configData.vacation_colors = {};
+      }
+      this.configData.vacation_colors[vacation] = color;
+      this.vacationColors = { ...this.vacationColors, [vacation]: color };
     },
     getAssignmentLabel(assignment) {
       if (!assignment) return '';
@@ -1081,6 +1348,68 @@ button:disabled {
   font-weight: bold;
 }
 
+.config-note {
+  color: #6c757d;
+  font-size: 14px;
+  margin: 4px 0 10px;
+}
+
+.half-vacation-card {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #dce8f7;
+  border-radius: 8px;
+  background: white;
+}
+
+.half-vacation-header {
+  display: grid;
+  grid-template-columns: 140px 110px 140px 150px;
+  gap: 10px;
+  align-items: center;
+}
+
+.half-vacation-header input[type="number"] {
+  max-width: 110px;
+  margin: 2px 0 0;
+}
+
+.half-segments {
+  margin-top: 10px;
+}
+
+.half-segment-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.2fr) minmax(100px, 1fr) 90px 90px 70px 90px 42px;
+  gap: 8px;
+  align-items: end;
+  margin-top: 8px;
+}
+
+.half-segment-row input[type="text"],
+.half-segment-row input[type="number"] {
+  margin: 2px 0 0;
+  max-width: none;
+}
+
+.half-segment-row input[type="color"] {
+  width: 54px;
+  height: 34px;
+  padding: 2px;
+  margin-top: 2px;
+}
+
+.inline-control {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.compact-btn {
+  padding: 6px 10px;
+  margin-bottom: 0;
+}
+
 .agent-card {
   margin-top: 12px;
   padding: 12px;
@@ -1256,7 +1585,9 @@ button:disabled {
 }
 
 @media (max-width: 900px) {
-  .vacation-row {
+  .vacation-row,
+  .half-vacation-header,
+  .half-segment-row {
     grid-template-columns: 1fr;
     justify-items: start;
   }

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -20,8 +20,13 @@
         <tbody>
           <tr v-for="(agent, index) in Object.keys(planning)" :key="index">
             <td>{{ agent }}</td>
-            <td v-for="day in monthDays" :key="day" :style="{ backgroundColor: getColumnColor(agent, day) }">
-              {{ getVacationForAgent(agent, day) || '//' }}
+            <td
+              v-for="day in monthDays"
+              :key="day"
+              :style="{ backgroundColor: getColumnColor(agent, day) }"
+              :title="getCellTitle(agent, day)"
+            >
+              {{ getDisplayValueForAgent(agent, day) || '//' }}
             </td>
             <td>{{ calculateNumberShifts(agent, monthDays) }}</td>
             <td>{{ calculateTotalHours(agent, monthDays) }} h</td>
@@ -73,6 +78,11 @@ export default {
       default: () => ({})
     },
     restrictionDurations: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    },
+    assignmentLabels: {
       type: Object,
       required: false,
       default: () => ({})
@@ -231,6 +241,30 @@ export default {
       }
       return this.planningLookup?.[agent]?.[day] || null;
     },
+    getWorkedAssignmentForAgent(agent, day) {
+      return this.planningLookup?.[agent]?.[day] || null;
+    },
+    getAssignmentLabel(assignment) {
+      return this.assignmentLabels?.[assignment] || assignment;
+    },
+    getDisplayValueForAgent(agent, day) {
+      const statusOrVacation = this.getVacationForAgent(agent, day);
+      if (!statusOrVacation) {
+        return null;
+      }
+      const workedAssignment = this.getWorkedAssignmentForAgent(agent, day);
+      if (workedAssignment && statusOrVacation === workedAssignment) {
+        return this.getAssignmentLabel(workedAssignment);
+      }
+      return statusOrVacation;
+    },
+    getCellTitle(agent, day) {
+      const workedAssignment = this.getWorkedAssignmentForAgent(agent, day);
+      if (workedAssignment && this.assignmentLabels?.[workedAssignment]) {
+        return workedAssignment;
+      }
+      return this.getVacationForAgent(agent, day) || '';
+    },
     isVacationDay(agent, day) {
       const vacations = this.dayOff?.[agent] || [];
       const dayDate = this.resolveDayDate(day);
@@ -325,12 +359,12 @@ export default {
         if (restriction && this.restrictionDurations?.[restriction.type]) {
           return total + this.restrictionDurations[restriction.type];
         }
-        const vacation = this.getVacationForAgent(agent, day);
+        const vacation = this.getWorkedAssignmentForAgent(agent, day);
         return total + (this.vacationDurations[vacation] || 0);
       }, 0);
     },
     calculateNumberShifts(agent, days) {
-      return days.filter((day) => this.getVacationForAgent(agent, day)).length;
+      return days.filter((day) => this.getWorkedAssignmentForAgent(agent, day)).length;
     }
   }
 };

--- a/frontend/src/components/PlanningTable.vue
+++ b/frontend/src/components/PlanningTable.vue
@@ -13,7 +13,7 @@
           <tr>
             <th>Agent</th>
             <th v-for="day in monthDays" :key="day">{{ day }}</th>
-            <th>Total Vacations</th>
+            <th>Total affectations</th>
             <th>Total Heures</th>
           </tr>
         </thead>

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -188,4 +188,59 @@ describe('App.vue', () => {
       'Jour apres-midi': '#00C853',
     });
   });
+
+  it('renders structured blocking reason segments', async () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      activeMode: 'planning',
+      generationMode: 'existing',
+      optimizationBlockingReasons: [
+        {
+          code: 'STAFFING_REQUIREMENT_UNMET',
+          message: 'Le besoin de couverture ne peut pas etre atteint.',
+          count: 1,
+          segments: [
+            {
+              date: '2026-01-15',
+              vacation: 'Jour',
+              segment: 'Jour matin',
+              required_agents: 2,
+              eligible_agents: 0,
+              blockers: {
+                status: 2,
+                parent_restriction: 1,
+              },
+              actions: ['free_agent', 'reduce_staffing_requirement'],
+              sample_blocked_agents: [
+                {
+                  agent: 'Agent1',
+                  reasons: ['status'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain('2026-01-15 / Jour / Jour matin');
+    expect(text).toContain('Besoin: 2');
+    expect(text).toContain('Agents possibles: 0');
+    expect(text).toContain('statut bloquant (2)');
+    expect(text).toContain('restriction parent (1)');
+    expect(text).toContain('liberer un agent');
+    expect(text).toContain('reduire le besoin de couverture');
+    expect(text).toContain('Agent1: statut bloquant');
+  });
 });

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -1,0 +1,65 @@
+import { shallowMount } from '@vue/test-utils';
+import App from '../src/App.vue';
+
+jest.mock('../src/apiClient', () => ({
+  apiGet: jest.fn(() => Promise.resolve({
+    data: {
+      agents: [],
+      vacations: ['Jour', 'Nuit'],
+      vacation_durations: {
+        Jour: 12,
+        Nuit: 12,
+        Conge: 7,
+      },
+      staffing_requirements: {
+        Jour: 1,
+        Nuit: 1,
+      },
+      holidays: [],
+      solver: {},
+      half_vacations: {},
+      vacation_colors: {},
+    },
+  })),
+  apiPost: jest.fn(),
+  apiPut: jest.fn(),
+  normalizeApiError: jest.fn((error, fallback) => fallback),
+}));
+
+describe('App.vue', () => {
+  it('renders modified existing assignments with labels', async () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      activeMode: 'planning',
+      generationMode: 'existing',
+      assignmentLabels: {
+        'Jour matin': 'J matin',
+      },
+      optimizationModifiedAssignments: [
+        {
+          agent: 'Agent1',
+          date: '2026-01-05',
+          initial_value: 'Jour matin',
+          final_value: 'Nuit',
+          change_type: 'changed_to_full',
+        },
+      ],
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain('Agent1');
+    expect(text).toContain('J matin');
+    expect(text).toContain('Nuit');
+    expect(text).toContain('2026-01-05');
+  });
+});

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -183,5 +183,9 @@ describe('App.vue', () => {
       { name: 'Jour matin', duration: 6, label: 'J matin' },
       { name: 'Jour apres-midi', duration: 6, label: 'J aprem' },
     ]);
+    expect(payload.vacation_colors).toEqual({
+      'Jour matin': '#B9F6CA',
+      'Jour apres-midi': '#00C853',
+    });
   });
 });

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -27,6 +27,10 @@ jest.mock('../src/apiClient', () => ({
 }));
 
 describe('App.vue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders modified existing assignments with labels', async () => {
     const wrapper = shallowMount(App, {
       global: {
@@ -61,5 +65,123 @@ describe('App.vue', () => {
     expect(text).toContain('J matin');
     expect(text).toContain('Nuit');
     expect(text).toContain('2026-01-05');
+  });
+
+  it('renders half-vacation config only for splittable vacations', async () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      activeMode: 'config',
+      configData: {
+        agents: [],
+        vacations: ['Jour', 'CDP'],
+        vacation_durations: {
+          Jour: 12,
+          CDP: 5.5,
+          Conge: 7,
+        },
+        staffing_requirements: {
+          Jour: 1,
+          CDP: 1,
+        },
+        holidays: [],
+        solver: {},
+        half_vacations: {},
+        vacation_colors: {},
+      },
+    });
+
+    expect(wrapper.findAll('.half-vacation-card')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Jour');
+    expect(wrapper.text()).toContain("CDP n'est pas decoupable.");
+  });
+
+  it('normalizes half-vacations payload and excludes CDP', async () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      vacationsInput: 'Jour, CDP',
+      holidaysInput: '',
+      configData: {
+        agents: [],
+        vacations: ['Jour', 'CDP'],
+        vacation_durations: {
+          Jour: 12,
+          CDP: 5.5,
+          Conge: 7,
+        },
+        staffing_requirements: {
+          Jour: 1,
+          CDP: 1,
+        },
+        holidays: [],
+        solver: {},
+        half_vacations: {
+          Jour: {
+            enabled: true,
+            penalty: 500,
+            segments: [
+              {
+                name: 'Jour matin',
+                label: 'J matin',
+                duration: 6,
+                is_night: false,
+                requires_next_day_rest: false,
+              },
+              {
+                name: 'Jour apres-midi',
+                label: 'J aprem',
+                duration: 6,
+                is_night: false,
+                requires_next_day_rest: false,
+              },
+            ],
+          },
+          CDP: {
+            enabled: true,
+            penalty: 100,
+            segments: [
+              { name: 'CDP 1', duration: 2.75 },
+              { name: 'CDP 2', duration: 2.75 },
+            ],
+          },
+          Nuit: {
+            enabled: false,
+            penalty: 700,
+            segments: [],
+          },
+        },
+        vacation_colors: {
+          'Jour matin': '#B9F6CA',
+          'Jour apres-midi': '#00C853',
+        },
+      },
+    });
+
+    const payload = wrapper.vm.buildConfigPayload();
+
+    expect(Object.keys(payload.half_vacations)).toEqual(['Jour']);
+    expect(payload.half_vacations.Jour.segments).toEqual([
+      { name: 'Jour matin', duration: 6, label: 'J matin' },
+      { name: 'Jour apres-midi', duration: 6, label: 'J aprem' },
+    ]);
   });
 });

--- a/frontend/tests/PlanningTable.spec.js
+++ b/frontend/tests/PlanningTable.spec.js
@@ -139,4 +139,42 @@ describe('PlanningTable.vue', () => {
     expect(text).not.toContain('Jour');
     expect(text).not.toContain('Nuit');
   });
+
+  it('uses assignment labels while keeping worked-hour and worked-assignment totals', () => {
+    const wrapper = shallowMount(PlanningTable, {
+      props: {
+        planning: {
+          Agent1: [['Lun. 05-01', 'Jour matin']],
+        },
+        weekSchedule: ['Lun. 05-01', 'Mar. 06-01'],
+        vacationDurations: {
+          'Jour matin': 6,
+        },
+        vacationColors: {
+          'Jour matin': '#B9F6CA',
+        },
+        assignmentLabels: {
+          'Jour matin': 'J matin',
+        },
+        holidays: [],
+        unavailable: {
+          Agent1: ['06-01-2026'],
+        },
+        dayOff: {
+          Agent1: [],
+        },
+        training: {
+          Agent1: [],
+        },
+        planningStartDate: '2026-01-05',
+      },
+    });
+
+    const text = wrapper.text();
+    expect(text).toContain('J matin');
+    expect(text).toContain('Ind.');
+    expect(text).toContain('1');
+    expect(text).toContain('6 h');
+    expect(wrapper.find('tbody td[title="Jour matin"]').exists()).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Delivers the full half-day / half-night feature set, including backend split-shift support, frontend display and configuration editing, existing-schedule optimization improvements, structured diagnostics, and final documentation updates.

This PR completes the main `half-day-half-night` workstream before moving on to the next functional topic.

## Changes

### Backend

- Added configurable half-vacations through `half_vacations`.
- Added segment-based coverage so parent shifts can be covered by full shifts or matching half-vacation segments.
- Added labels and metadata for assignments, including night and next-day-rest behavior.
- Added runtime validation to reject `half_vacations.CDP`.
- Preserved the historical hard `CDP <= 2/week` business rule as an explicit exception.
- Added `assignment_labels` to generation responses.
- Added `modified_existing_assignments` to report changes made during existing-schedule optimization.
- Changed existing assignments from hard locks to preserved assignments handled through the objective.
- Kept hard non-working statuses such as unavailable, training, vacations, and restrictions.
- Changed the historical minimum-assignment constraint into a weak objective bonus.
- Added structured backend diagnostics for infeasible optimization cases.

### Frontend

- Displayed assignment labels for full and half-vacations.
- Added display for modified existing assignments.
- Added structured optimization diagnostics in the UI.
- Added half-vacation configuration editing for segments, durations, labels, colors, penalties, night flags, and next-day rest flags.
- Cleaned stale segment colors before saving config.
- Updated planning totals so worked assignments and worked hours are counted consistently.

### Documentation

- Updated README with half-vacation and existing-schedule optimization features.
- Expanded config documentation for `half_vacations`, `vacation_colors`, and `vacation_metadata`.
- Added changelog entries for the full feature set.
- Marked the existing-schedule MVP document as historical context now that the implementation has evolved.

## Validation

- Backend: `.\.venv\Scripts\python.exe -m pytest tests -q`
  - `119 passed`
- Frontend: `npm test -- --runInBand`
  - `12 passed`
