### PR TITLE
split overnight shift hours across weeks

### DIFF
--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -148,6 +148,14 @@
       ]
     }
   },
+  "vacation_metadata": {
+    "Nuit": {
+      "is_night": true,
+      "requires_next_day_rest": true,
+      "start_time": "19:00",
+      "end_time": "07:00"
+    }
+  },
   "vacation_colors": {
     "Jour": "#75FA79",
     "Jour matin": "#B9F6CA",

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -238,6 +238,12 @@
         },
         "requires_next_day_rest": {
           "type": "boolean"
+        },
+        "start_time": {
+          "$ref": "#/$defs/time_of_day"
+        },
+        "end_time": {
+          "$ref": "#/$defs/time_of_day"
         }
       }
     },
@@ -290,8 +296,18 @@
         },
         "requires_next_day_rest": {
           "type": "boolean"
+        },
+        "start_time": {
+          "$ref": "#/$defs/time_of_day"
+        },
+        "end_time": {
+          "$ref": "#/$defs/time_of_day"
         }
       }
+    },
+    "time_of_day": {
+      "type": "string",
+      "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$"
     }
   }
 }

--- a/backend/solver/catalog.py
+++ b/backend/solver/catalog.py
@@ -18,6 +18,8 @@ class AssignmentMetadata:
     penalty: int = 0
     is_night: bool = False
     requires_next_day_rest: bool = False
+    start_time: str | None = None
+    end_time: str | None = None
 
 
 def _duration_to_tenths(value: Any, field_name: str) -> int:
@@ -69,6 +71,8 @@ def build_vacation_catalog(config: dict[str, Any]) -> dict[str, Any]:
             label=parent_metadata.get("label", parent),
             is_night=parent_is_night,
             requires_next_day_rest=parent_requires_rest,
+            start_time=parent_metadata.get("start_time"),
+            end_time=parent_metadata.get("end_time"),
         )
         assignable_vacations.append(parent)
 
@@ -112,6 +116,8 @@ def build_vacation_catalog(config: dict[str, Any]) -> dict[str, Any]:
                     penalty=penalty,
                     is_night=segment_is_night,
                     requires_next_day_rest=segment_requires_rest,
+                    start_time=segment.get("start_time", parent_metadata.get("start_time")),
+                    end_time=segment.get("end_time", parent_metadata.get("end_time")),
                 )
                 assignable_vacations.append(segment_name)
                 segment_covering_assignments[(parent, segment_name)] = [parent, segment_name]

--- a/backend/solver/constraints/mixed.py
+++ b/backend/solver/constraints/mixed.py
@@ -1,5 +1,6 @@
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
+from ..utils import weekly_hour_contribution_tenths
 
 DAY_SHIFT = "Jour"
 NIGHT_SHIFT = "Nuit"
@@ -21,17 +22,42 @@ def register(registry: ConstraintRegistry) -> None:
 
 def limit_weekly_worked_hours(ctx: SolverContext) -> None:
     """Caps weekly worked hours using solver.max_weekly_hours."""
+    assignable_vacations = getattr(ctx, "assignable_vacations", None) or ctx.vacations
+    day_dates = getattr(ctx, "day_dates", {}) or {}
+    assignment_metadata = getattr(ctx, "assignment_metadata", {}) or {}
+
     for agent in ctx.agents:
         agent_name = agent["name"]
 
         for week in ctx.weeks_split:
-            assignable_vacations = getattr(ctx, "assignable_vacations", None) or ctx.vacations
+            if not day_dates:
+                days_to_count = week
+                week_key = None
+            else:
+                week_day_dates = [day_dates[day] for day in week if day in day_dates]
+                if not week_day_dates:
+                    days_to_count = week
+                    week_key = None
+                else:
+                    days_to_count = ctx.week_schedule
+                    week_key = week_day_dates[0].isocalendar()[:2]
+
             total_hours = sum(
                 sum(
-                    ctx.planning[(agent_name, day, vacation)] * ctx.shift_durations[vacation]
+                    ctx.planning[(agent_name, day, vacation)]
+                    * (
+                        weekly_hour_contribution_tenths(
+                            day_dates.get(day),
+                            assignment_metadata.get(vacation),
+                            ctx.shift_durations[vacation],
+                            week_key,
+                        )
+                        if week_key is not None
+                        else ctx.shift_durations[vacation]
+                    )
                     for vacation in assignable_vacations
                 )
-                for day in week
+                for day in days_to_count
             )
             ctx.model.Add(total_hours <= ctx.max_weekly_hours)
 

--- a/backend/solver/utils.py
+++ b/backend/solver/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
 
 
 def split_into_weeks(week_schedule):
@@ -71,3 +71,30 @@ def day_token(date_full: str) -> str:
     :rtype: str
     """
     return datetime.strptime(date_full, "%d-%m-%Y").strftime("%d-%m")
+
+
+def _parse_time_of_day(value: str) -> time:
+    return datetime.strptime(value, "%H:%M").time()
+
+
+def weekly_hour_contribution_tenths(day_date, metadata, fallback_duration, week_key):
+    """Return assignment hours that belong to an ISO week, in tenths of hours."""
+    if not day_date or not metadata or not metadata.start_time or not metadata.end_time:
+        return fallback_duration if day_date and day_date.isocalendar()[:2] == week_key else 0
+
+    start_time = _parse_time_of_day(metadata.start_time)
+    end_time = _parse_time_of_day(metadata.end_time)
+    start_at = datetime.combine(day_date.date(), start_time)
+    end_at = datetime.combine(day_date.date(), end_time)
+    if end_at <= start_at:
+        end_at += timedelta(days=1)
+
+    week_monday = date.fromisocalendar(week_key[0], week_key[1], 1)
+    week_start = datetime.combine(week_monday, time.min)
+    week_end = week_start + timedelta(days=7)
+
+    overlap_start = max(start_at, week_start)
+    overlap_end = min(end_at, week_end)
+    if overlap_end <= overlap_start:
+        return 0
+    return int(round((overlap_end - overlap_start).total_seconds() / 360))

--- a/backend/tests/test_config_schema.py
+++ b/backend/tests/test_config_schema.py
@@ -87,6 +87,42 @@ def test_schema_accepts_max_weekly_hours():
     assert errors == []
 
 
+def test_schema_accepts_temporal_vacation_metadata():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example.setdefault("vacation_metadata", {})["Nuit"] = {
+        "is_night": True,
+        "requires_next_day_rest": True,
+        "start_time": "19:00",
+        "end_time": "07:00",
+    }
+    example["half_vacations"]["Nuit"]["segments"][0]["start_time"] = "19:00"
+    example["half_vacations"]["Nuit"]["segments"][0]["end_time"] = "01:00"
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors == []
+
+
+def test_schema_rejects_invalid_temporal_vacation_metadata_time():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example.setdefault("vacation_metadata", {})["Nuit"] = {
+        "start_time": "24:00",
+        "end_time": "07:00",
+    }
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors != []
+    assert any(
+        "start_time" in "/".join(str(part) for part in error.path)
+        for error in errors
+    )
+
+
 @pytest.mark.parametrize("max_weekly_hours", [0, -1])
 def test_schema_rejects_non_positive_max_weekly_hours(max_weekly_hours):
     schema = _load_json(SCHEMA_PATH)

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -1,9 +1,11 @@
 from copy import deepcopy
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 from ortools.sat.python import cp_model
 from app import generate_planning, get_active_config, load_default_config, set_active_config
+from solver.catalog import AssignmentMetadata
 from solver.constraints.mixed import limit_weekly_nights_and_hours
 
 
@@ -37,6 +39,72 @@ def _solve_forced_weekly_shifts(max_weekly_hours):
         ("Mar. 02-06", "Jour"),
         ("Mer. 03-06", "Nuit"),
         ("Jeu. 04-06", "Nuit"),
+    }
+    for day in week:
+        for vacation in vacations:
+            model.Add(
+                planning[(agent_name, day, vacation)]
+                == int((day, vacation) in forced_shifts)
+            )
+
+    solver = cp_model.CpSolver()
+    return solver.Solve(model)
+
+
+def _solve_forced_temporal_weekly_shifts(max_weekly_hours):
+    model = cp_model.CpModel()
+    agent_name = "Agent1"
+    vacations = ["Jour", "Nuit"]
+    week = [
+        "Lun. 05-01",
+        "Mar. 06-01",
+        "Mer. 07-01",
+        "Jeu. 08-01",
+        "Ven. 09-01",
+        "Sam. 10-01",
+        "Dim. 11-01",
+    ]
+    planning = {
+        (agent_name, day, vacation): model.NewBoolVar(
+            f"planning_{agent_name}_{day}_{vacation}"
+        )
+        for day in week
+        for vacation in vacations
+    }
+    start_date = datetime(2026, 1, 5)
+
+    ctx = SimpleNamespace(
+        agents=[{"name": agent_name}],
+        vacations=vacations,
+        assignable_vacations=vacations,
+        weeks_split=[week],
+        week_schedule=week,
+        planning=planning,
+        day_dates={day: start_date + timedelta(days=index) for index, day in enumerate(week)},
+        assignment_metadata={
+            "Jour": AssignmentMetadata(name="Jour", parent="Jour", duration=120),
+            "Nuit": AssignmentMetadata(
+                name="Nuit",
+                parent="Nuit",
+                duration=120,
+                is_night=True,
+                requires_next_day_rest=True,
+                start_time="19:00",
+                end_time="07:00",
+            ),
+        },
+        shift_durations={"Jour": 120, "Nuit": 120},
+        max_weekly_hours=max_weekly_hours,
+        model=model,
+    )
+
+    limit_weekly_nights_and_hours(ctx)
+
+    forced_shifts = {
+        ("Mar. 06-01", "Jour"),
+        ("Ven. 09-01", "Nuit"),
+        ("Sam. 10-01", "Nuit"),
+        ("Dim. 11-01", "Nuit"),
     }
     for day in week:
         for vacation in vacations:
@@ -736,6 +804,17 @@ def test_weekly_hours_limit_uses_configured_cap():
     """
 
     status = _solve_forced_weekly_shifts(max_weekly_hours=480)
+
+    assert status in [cp_model.OPTIMAL, cp_model.FEASIBLE]
+
+
+def test_weekly_hours_limit_splits_sunday_overnight_shift():
+    """
+    Tuesday day + Friday/Saturday nights + Sunday night is 41h in the current
+    week when Sunday 19:00-07:00 contributes only 5h before Monday.
+    """
+
+    status = _solve_forced_temporal_weekly_shifts(max_weekly_hours=450)
 
     assert status in [cp_model.OPTIMAL, cp_model.FEASIBLE]
     

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 from app import (
@@ -12,6 +13,7 @@ from app import (
     split_date_range_by_month,
     split_into_weeks,
 )
+from solver.utils import weekly_hour_contribution_tenths
 
 
 def test_is_valid_date_valid():
@@ -131,6 +133,40 @@ def test_format_day_label_is_locale_independent():
     assert format_day_label(datetime(2026, 1, 5)) == "Lun. 05-01"
     assert format_day_label(datetime(2026, 1, 6)) == "Mar. 06-01"
     assert format_day_label(datetime(2026, 1, 11)) == "Dim. 11-01"
+
+
+def test_weekly_hour_contribution_uses_nominal_day_without_temporal_metadata():
+    day_date = datetime(2026, 1, 11)
+
+    current_week = weekly_hour_contribution_tenths(
+        day_date, SimpleNamespace(start_time=None, end_time=None), 120, (2026, 2)
+    )
+    next_week = weekly_hour_contribution_tenths(
+        day_date, SimpleNamespace(start_time=None, end_time=None), 120, (2026, 3)
+    )
+
+    assert current_week == 120
+    assert next_week == 0
+
+
+def test_weekly_hour_contribution_counts_same_day_shift_fully():
+    day_date = datetime(2026, 1, 6)
+    metadata = SimpleNamespace(start_time="07:00", end_time="19:00")
+
+    contribution = weekly_hour_contribution_tenths(day_date, metadata, 120, (2026, 2))
+
+    assert contribution == 120
+
+
+def test_weekly_hour_contribution_splits_sunday_overnight_shift():
+    day_date = datetime(2026, 1, 11)
+    metadata = SimpleNamespace(start_time="19:00", end_time="07:00")
+
+    current_week = weekly_hour_contribution_tenths(day_date, metadata, 120, (2026, 2))
+    next_week = weekly_hour_contribution_tenths(day_date, metadata, 120, (2026, 3))
+
+    assert current_week == 50
+    assert next_week == 70
 
 
 def test_get_week_schedule_single_day():

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -167,7 +167,9 @@ Example:
   "Nuit": {
     "label": "N",
     "is_night": true,
-    "requires_next_day_rest": true
+    "requires_next_day_rest": true,
+    "start_time": "19:00",
+    "end_time": "07:00"
   }
 }
 ```
@@ -176,6 +178,10 @@ Notes:
 
 - `is_night` marks an assignment as a night assignment for night-specific safety rules.
 - `requires_next_day_rest` blocks non-night work on the following day.
+- `start_time` and `end_time` are optional `HH:MM` values used only by `solver.max_weekly_hours`.
+- If `end_time` is less than or equal to `start_time`, the shift is treated as ending the next day.
+- Example: a Sunday `Nuit` from `19:00` to `07:00` contributes 5h to the Sunday week and 7h to the next Monday week.
+- If either time is missing, the full `vacation_durations` value is counted on the assignment day, preserving legacy behavior.
 - Segment-level metadata in `half_vacations[].segments[]` overrides or inherits from the parent behavior.
 
 ### `holidays` (required)


### PR DESCRIPTION
## Objective
Add temporal weekly-hour accounting so overnight vacations can contribute worked hours to the correct ISO week instead of being counted entirely on the nominal assignment day.

This fixes Sunday-to-Monday night accounting for `solver.max_weekly_hours`, while preserving duration-based behavior when no temporal metadata is configured.

## Breaking Change Notice
No API breaking change.

Existing configurations keep the same behavior unless optional `start_time` and `end_time` metadata are added. Balancing, display durations, half-vacation coverage, and rest/safety rules continue to use the existing duration and metadata model.

## Scope
- Add optional `start_time` and `end_time` fields to `vacation_metadata`.
- Add the same optional temporal fields to `half_vacations[].segments[]`.
- Carry temporal metadata through `AssignmentMetadata`.
- Add weekly contribution calculation for shifts that cross midnight.
- Apply temporal splitting only to `solver.max_weekly_hours`.
- Preserve legacy duration-based weekly counting when temporal metadata is absent.
- Update config schema, example config, and config reference documentation.
- Add regression tests for:
  - schema validation of temporal metadata
  - same-day and Sunday-to-Monday hour contribution calculations
  - weekly cap feasibility for Tuesday day + Friday/Saturday/Sunday nights
  - existing half-vacation behavior

## Validation
- `backend\.venv\Scripts\python.exe -m pytest backend\tests`

## Results
- Backend test suite passes globally: `125/125`.
- Sunday `Nuit` configured as `19:00` to `07:00` now contributes 5h to the Sunday week and 7h to the following Monday week.
- Existing half-vacation tests continue to pass unchanged.

## Risks and Mitigations
- Risk: schedules with temporal metadata may now be evaluated differently around week boundaries.
- Mitigation: behavior is opt-in via `start_time` / `end_time`; configurations without those fields keep legacy weekly counting.
- Risk: temporal accounting could be confused with payroll-grade tracking.
- Mitigation: v1 is intentionally limited to `solver.max_weekly_hours` and single overnight intervals.