### PR TITLE
Add strict locking option for existing schedule optimization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -265,7 +265,9 @@ def _build_planning_payload(payload, runtime_config):
                 return {"error": f"Invalid vacation: {vacation}"}, 400
             validated_existing_assignments[(agent_name, day)] = vacation
 
-    for chunk_start, chunk_end in periods:
+    locked_initial_shifts = deepcopy(initial_shifts)
+
+    for chunk_index, (chunk_start, chunk_end) in enumerate(periods):
         # Convert the start and end dates into strings
         start_date_str = chunk_start.strftime("%Y-%m-%d")
         end_date_str = chunk_end.strftime("%Y-%m-%d")
@@ -276,13 +278,18 @@ def _build_planning_payload(payload, runtime_config):
 
         # Calling up the schedule generation function
         try:
+            chunk_initial_shifts = deepcopy(initial_shifts)
+            if chunk_index > 0:
+                for agent_name, shifts in locked_initial_shifts.items():
+                    chunk_initial_shifts.setdefault(agent_name, []).extend(shifts)
+
             result = generate_planning(
                 agents,
                 vacations,
                 week_schedule,
                 dayOff,
                 previous_week_schedule,
-                initial_shifts,
+                chunk_initial_shifts,
                 planning_start_date=start_date_str,
                 runtime_config=runtime_config,
                 existing_assignments=validated_existing_assignments,
@@ -1198,12 +1205,13 @@ def optimize_existing_planning_route():
         runtime_config, status_entries
     )
     warnings.extend(status_warnings)
+    existing_assignments_strict = bool(payload.get("existing_assignments_strict", True))
 
     result, status_code = _build_planning_payload(
         payload={
             "start_date": payload["start_date"],
             "end_date": payload["end_date"],
-            "initial_shifts": {},
+            "initial_shifts": existing_assignments if existing_assignments_strict else {},
             "existing_assignments": existing_assignments,
         },
         runtime_config=effective_runtime_config,
@@ -1227,7 +1235,7 @@ def optimize_existing_planning_route():
                 planning_payload={
                     "start_date": payload["start_date"],
                     "end_date": payload["end_date"],
-                    "initial_shifts": {},
+                    "initial_shifts": existing_assignments if existing_assignments_strict else {},
                     "existing_assignments": existing_assignments,
                 },
                 runtime_config=effective_runtime_config,
@@ -1272,6 +1280,7 @@ def optimize_existing_planning_route():
                     "meta": {
                         "manual_cell_count": len(manual_entries),
                         "conflict_count": len(warnings),
+                        "existing_assignments_strict": existing_assignments_strict,
                     },
                 }
             ),
@@ -1295,6 +1304,7 @@ def optimize_existing_planning_route():
     result["meta"] = {
         "manual_cell_count": len(manual_entries),
         "conflict_count": len(warnings),
+        "existing_assignments_strict": existing_assignments_strict,
     }
     return jsonify(result)
 

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -310,6 +310,90 @@ def test_optimize_existing_planning_accepts_manual_shift_and_returns_ok_status(c
     assert [forced_day_label, forced_vacation] in payload["planning"][agent_name]
 
 
+def test_optimize_existing_planning_locks_manual_shifts_by_default(client):
+    agent_name = load_default_config()["agents"][0]["name"]
+    data = {
+        "start_date": "2026-01-05",
+        "end_date": "2026-01-05",
+        "manual_entries": [
+            {
+                "agent": agent_name,
+                "date": "2026-01-05",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            }
+        ],
+    }
+    fake_result = {
+        "planning": {agent_name: [["Lun. 05-01", "Jour"]]},
+        "vacation_durations": {"Jour": 12, "Conge": 7},
+        "vacation_colors": {},
+        "assignable_vacations": ["Jour"],
+        "assignment_labels": {"Jour": "Jour"},
+        "week_schedule": ["Lun. 05-01"],
+        "holidays": [],
+        "unavailable": {},
+        "dayOff": {},
+        "training": {},
+        "restrictions": {},
+        "restriction_types_durations": {},
+    }
+
+    with patch("app._build_planning_payload", return_value=(fake_result, 200)) as build_payload:
+        response = client.post(
+            "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+        )
+
+    assert response.status_code == 200
+    planning_payload = build_payload.call_args.kwargs["payload"]
+    assert planning_payload["initial_shifts"] == {agent_name: [("Lun. 05-01", "Jour")]}
+    assert response.get_json()["meta"]["existing_assignments_strict"] is True
+
+
+def test_optimize_existing_planning_can_keep_manual_shifts_soft(client):
+    agent_name = load_default_config()["agents"][0]["name"]
+    data = {
+        "start_date": "2026-01-05",
+        "end_date": "2026-01-05",
+        "existing_assignments_strict": False,
+        "manual_entries": [
+            {
+                "agent": agent_name,
+                "date": "2026-01-05",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            }
+        ],
+    }
+    fake_result = {
+        "planning": {agent_name: [["Lun. 05-01", "Jour"]]},
+        "vacation_durations": {"Jour": 12, "Conge": 7},
+        "vacation_colors": {},
+        "assignable_vacations": ["Jour"],
+        "assignment_labels": {"Jour": "Jour"},
+        "week_schedule": ["Lun. 05-01"],
+        "holidays": [],
+        "unavailable": {},
+        "dayOff": {},
+        "training": {},
+        "restrictions": {},
+        "restriction_types_durations": {},
+    }
+
+    with patch("app._build_planning_payload", return_value=(fake_result, 200)) as build_payload:
+        response = client.post(
+            "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+        )
+
+    assert response.status_code == 200
+    planning_payload = build_payload.call_args.kwargs["payload"]
+    assert planning_payload["initial_shifts"] == {}
+    assert planning_payload["existing_assignments"] == {agent_name: [("Lun. 05-01", "Jour")]}
+    assert response.get_json()["meta"]["existing_assignments_strict"] is False
+
+
 def test_optimize_existing_planning_returns_warning_for_status_entries(client):
     data = {
         "start_date": "2026-01-05",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -427,6 +427,13 @@
         </div>
       </div>
 
+      <div v-if="isExistingOptimizationMode" class="existing-options">
+        <label class="inline-control">
+          <input type="checkbox" v-model="existingAssignmentsStrict" />
+          Verrouiller les vacations saisies
+        </label>
+      </div>
+
       <div>
         <button @click="generatePlanning" :disabled="isLoading || isConfigSaving">
           {{ isLoading ? "Génération en cours..." : actionButtonLabel }}
@@ -542,6 +549,7 @@ export default {
       selectedShifts: {},
       manualWeekSchedule: [],
       manualSelectedShifts: {},
+      existingAssignmentsStrict: true,
       optimizationWarnings: [],
       optimizationSuggestions: [],
       optimizationBlockingReasons: [],
@@ -1225,6 +1233,7 @@ export default {
       }
       if (this.isExistingOptimizationMode) {
         payload.manual_entries = [];
+        payload.existing_assignments_strict = this.existingAssignmentsStrict;
         Object.entries(this.manualSelectedShifts).forEach(([agent, days]) => {
           Object.entries(days || {}).forEach(([dayLabel, value]) => {
             if (!value) return;
@@ -1491,6 +1500,10 @@ button:disabled {
   display: inline-flex;
   gap: 6px;
   align-items: center;
+}
+
+.existing-options {
+  margin: 14px 0 10px;
 }
 
 .compact-btn {

--- a/frontend/tests/App.spec.js
+++ b/frontend/tests/App.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import App from '../src/App.vue';
+import { apiPost } from '../src/apiClient';
 
 jest.mock('../src/apiClient', () => ({
   apiGet: jest.fn(() => Promise.resolve({
@@ -242,5 +243,76 @@ describe('App.vue', () => {
     expect(text).toContain('liberer un agent');
     expect(text).toContain('reduire le besoin de couverture');
     expect(text).toContain('Agent1: statut bloquant');
+  });
+
+  it('sends the strict existing assignment option when optimizing existing planning', async () => {
+    apiPost.mockResolvedValueOnce({
+      data: {
+        planning: {},
+        vacation_durations: {},
+        assignment_labels: {},
+        vacation_colors: {},
+        assignable_vacations: ['Jour'],
+        week_schedule: ['Lun. 05-01'],
+        holidays: [],
+        unavailable: {},
+        dayOff: {},
+        training: {},
+        restrictions: {},
+        restriction_types_durations: {},
+        warnings: [],
+        suggestions: [],
+        blocking_reasons: [],
+        impacted_cells: [],
+        modified_existing_assignments: [],
+        meta: { existing_assignments_strict: false },
+        status: 'ok',
+      },
+    });
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          PlanningTable: true,
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.setData({
+      activeMode: 'planning',
+      generationMode: 'existing',
+      startDate: '2026-01-05',
+      endDate: '2026-01-05',
+      existingAssignmentsStrict: false,
+      agents: [{ name: 'Agent1' }],
+      manualWeekSchedule: ['Lun. 05-01'],
+    });
+    await wrapper.vm.$nextTick();
+    await wrapper.setData({
+      manualSelectedShifts: {
+        Agent1: {
+          'Lun. 05-01': 'Jour',
+        },
+      },
+    });
+
+    await wrapper.vm.generatePlanning();
+
+    expect(apiPost).toHaveBeenCalledWith('/optimize-existing-planning', {
+      start_date: '2026-01-05',
+      end_date: '2026-01-05',
+      manual_entries: [
+        {
+          agent: 'Agent1',
+          date: '2026-01-05',
+          slot: 'day',
+          type: 'shift',
+          value: 'Jour',
+        },
+      ],
+      existing_assignments_strict: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a UI checkbox to lock manually entered existing assignments during existing schedule optimization
- send the strict-locking option through the existing optimization API payload
- reuse initial shift constraints to make locked existing assignments hard constraints while keeping the previous soft behavior available
- keep locked assignments active across monthly optimization chunks

## Tests
- `backend/.venv/Scripts/python.exe -m pytest tests/test_routes.py -k "optimize_existing_planning"`
- `npm test -- --runInBand App.spec.js`