### PR TITLE
Allow consecutive locked night shifts without false warning

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -749,11 +749,14 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
         ]
         if rest_triggering_shifts:
             next_manual_shifts = manual_shifts_by_agent_day.get((agent_name, next_iso), [])
-            if next_manual_shifts:
+            forbidden_next_manual_shifts = [
+                shift for shift in next_manual_shifts if not is_night_assignment(catalog, shift)
+            ]
+            if forbidden_next_manual_shifts:
                 counts_by_code["MANUAL_SHIFT_AFTER_NIGHT"] += 1
                 details_by_code["MANUAL_SHIFT_AFTER_NIGHT"].append(
                     f"{agent_name} / {iso_date}: {', '.join(rest_triggering_shifts)} "
-                    f"suivie de {', '.join(next_manual_shifts)} le {next_iso}"
+                    f"suivie de {', '.join(forbidden_next_manual_shifts)} le {next_iso}"
                 )
             if next_day_str in (agent.get("unavailable") or []) or next_day_str in (agent.get("training") or []):
                 counts_by_code["MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING"] += 1
@@ -789,7 +792,7 @@ def _diagnose_manual_sequence_conflicts(manual_shifts_by_agent_day, runtime_conf
 
     reason_messages = {
         "MANUAL_CDP_WEEKLY_LIMIT_EXCEEDED": "La limite de 2 vacations CDP par semaine est dépassée par des saisies manuelles.",
-        "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle est posée le lendemain d'une affectation nécessitant un repos.",
+        "MANUAL_SHIFT_AFTER_NIGHT": "Une vacation manuelle non-nuit est posée le lendemain d'une affectation nécessitant un repos.",
         "MANUAL_NIGHT_BEFORE_UNAVAILABLE_OR_TRAINING": "Une affectation nécessitant un repos est posée avant une indisponibilité ou une formation.",
         "MANUAL_SHIFT_AROUND_TRAINING_NOT_ALLOWED": "Une vacation manuelle ne respecte pas les règles de veille/lendemain de formation.",
         "MANUAL_FULL_WEEKEND_COMPOSITION_CONFLICT": "Une saisie manuelle empêche de respecter la règle de week-end complet.",

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -351,6 +351,69 @@ def test_optimize_existing_planning_locks_manual_shifts_by_default(client):
     assert response.get_json()["meta"]["existing_assignments_strict"] is True
 
 
+def test_optimize_existing_planning_accepts_locked_consecutive_manual_nights(client):
+    config = deepcopy(load_default_config())
+    config["agents"] = [
+        {
+            "name": "Agent Nuit",
+            "preferences": {"preferred": ["Nuit"], "avoid": []},
+            "restriction": [],
+            "unavailable": [],
+            "training": [],
+            "exclusion": [],
+            "vacations": [],
+        },
+        {
+            "name": "Agent Jour",
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "restriction": [],
+            "unavailable": [],
+            "training": [],
+            "exclusion": [],
+            "vacations": [],
+        },
+    ]
+    config["vacations"] = ["Jour", "Nuit"]
+    config["staffing_requirements"] = {"Jour": 1, "Nuit": 1}
+    config["vacation_durations"] = {"Jour": 12, "Nuit": 12, "Conge": 7}
+    config["half_vacations"] = {}
+    config.setdefault("solver", {})["min_free_weekends_per_horizon"] = 0
+    set_active_config(config)
+
+    data = {
+        "start_date": "2026-01-12",
+        "end_date": "2026-01-13",
+        "manual_entries": [
+            {
+                "agent": "Agent Nuit",
+                "date": "2026-01-12",
+                "slot": "night",
+                "type": "shift",
+                "value": "Nuit",
+            },
+            {
+                "agent": "Agent Nuit",
+                "date": "2026-01-13",
+                "slot": "night",
+                "type": "shift",
+                "value": "Nuit",
+            },
+        ],
+    }
+
+    response = client.post(
+        "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert payload["warnings"] == []
+    assert payload["meta"]["existing_assignments_strict"] is True
+    assert ["Lun. 12-01", "Nuit"] in payload["planning"]["Agent Nuit"]
+    assert ["Mar. 13-01", "Nuit"] in payload["planning"]["Agent Nuit"]
+
+
 def test_optimize_existing_planning_can_keep_manual_shifts_soft(client):
     agent_name = load_default_config()["agents"][0]["name"]
     data = {
@@ -584,6 +647,34 @@ def test_diagnose_manual_entry_conflicts_detects_shift_after_night():
 
     reason_codes = [reason["code"] for reason in reasons]
     assert "MANUAL_SHIFT_AFTER_NIGHT" in reason_codes
+
+
+def test_diagnose_manual_entry_conflicts_allows_consecutive_manual_nights():
+    config = deepcopy(load_default_config())
+    agent_name = config["agents"][0]["name"]
+
+    reasons = _diagnose_manual_entry_conflicts(
+        [
+            {
+                "agent": agent_name,
+                "date": "2026-01-12",
+                "slot": "night",
+                "type": "shift",
+                "value": "Nuit",
+            },
+            {
+                "agent": agent_name,
+                "date": "2026-01-13",
+                "slot": "night",
+                "type": "shift",
+                "value": "Nuit",
+            },
+        ],
+        config,
+    )
+
+    reason_codes = [reason["code"] for reason in reasons]
+    assert "MANUAL_SHIFT_AFTER_NIGHT" not in reason_codes
 
 
 def test_probe_relaxed_hard_constraints_reports_feasible_relaxed_constraint():


### PR DESCRIPTION
## Summary

- Fixes the manual `MANUAL_SHIFT_AFTER_NIGHT` diagnostic so it only reports non-night assignments after a rest-triggering shift.
- Correctly allows locked `Nuit -> Nuit` sequences, which are already permitted by the solver hard constraint.
- Adds test coverage for the manual diagnostic and the strict locked-assignment optimization route.

## Tests

- `.\.venv\Scripts\python.exe -m pytest backend\tests\test_routes.py -k "manual_entry_conflicts or optimize_existing_planning" -q`
- `.\.venv\Scripts\python.exe -m pytest backend\tests\test_half_vacations.py -q`