### PR TITLE
Fix free weekend before leave

### DIFF
--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -15,6 +15,7 @@ from ..utils import day_token
 DAY_SHIFT = "Jour"
 NIGHT_SHIFT = "Nuit"
 CDP_SHIFT = "CDP"
+FRENCH_WEEKDAY_ABBREVIATIONS = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
 
 
 def _has_shift(ctx: SolverContext, shift_name: str) -> bool:
@@ -29,6 +30,11 @@ def _has_shift(ctx: SolverContext, shift_name: str) -> bool:
     :rtype: bool
     """
     return shift_name in ctx.vacations
+
+
+def _format_day_label(day_date: datetime) -> str:
+    day_name = FRENCH_WEEKDAY_ABBREVIATIONS[day_date.weekday()]
+    return f"{day_name}. {day_date.strftime('%d-%m')}"
 
 
 def register(registry: ConstraintRegistry) -> None:
@@ -375,7 +381,7 @@ def block_leave_and_compute_paid_hours(ctx: SolverContext) -> None:
                 previous_saturday = vacation_start - timedelta(days=2)
                 previous_sunday = vacation_start - timedelta(days=1)
                 for weekend_day in [previous_saturday, previous_sunday]:
-                    weekend_str = weekend_day.strftime("%a %d-%m").capitalize()
+                    weekend_str = _format_day_label(weekend_day)
                     if (
                         weekend_str in ctx.week_schedule
                         or weekend_str in ctx.previous_week_schedule

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -785,6 +785,75 @@ def test_generate_planning_ignores_leave_periods_from_other_years():
     assert "info" not in result
 
 
+def test_monday_leave_blocks_previous_weekend_with_french_day_labels():
+    """
+    Regression test: leave starting on Monday must block the preceding Saturday/Sunday.
+
+    The weekend labels must use the same French format as week_schedule; otherwise
+    the constraint silently misses the generated days.
+    """
+
+    agents = [
+        {
+            "name": "Agent1",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [{"start": "06-01-2025", "end": "10-01-2025"}],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Agent2",
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+    ]
+    vacations = ["Jour"]
+    week_schedule = [
+        "Sam. 04-01",
+        "Dim. 05-01",
+        "Lun. 06-01",
+    ]
+
+    result = generate_planning(
+        agents,
+        vacations,
+        week_schedule,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={
+            "Agent1": [
+                ("Sam. 04-01", "Jour"),
+                ("Dim. 05-01", "Jour"),
+            ]
+        },
+        planning_start_date="2025-01-04",
+        runtime_config={
+            "vacation_durations": {"Jour": 12, "Conge": 7},
+            "staffing_requirements": {"Jour": 1},
+            "holidays": [],
+            "solver": {
+                "max_time_seconds": 30,
+                "relative_gap_limit": 0.1,
+                "num_search_workers": 0,
+                "global_max_gap": 600,
+                "period_max_gap": 600,
+                "max_weekly_hours": 60,
+                "optimize_period_balance": False,
+                "period_balance_weight": 2,
+                "min_free_weekends_per_horizon": 0,
+            },
+        },
+    )
+
+    assert result == {"info": "No solution found."}
+
+
 def test_weekly_hours_limit_counts_night_shifts_with_default_cap():
     """
     Regression test: weekly hour cap must count night shifts, not only day/CDP.


### PR DESCRIPTION
## Summary

- Fixes the leave constraint that should block the Saturday/Sunday before a leave period starting on Monday.
- Replaces locale-dependent weekend labels (`Sat`/`Sun`) with the French schedule labels used by the solver (`Sam.`/`Dim.`).
- Adds regression coverage for the Monday-leave weekend blocking case.

## Tests

- `.\.venv\Scripts\python.exe -m pytest backend\tests`