### PR TITLE
Fix manual restriction diagnostics for existing schedule optimization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,7 +6,12 @@ from copy import deepcopy
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from jsonschema import Draft202012Validator
-from solver.catalog import build_vacation_catalog, is_night_assignment, requires_next_day_rest
+from solver.catalog import (
+    assignment_matches_choice,
+    build_vacation_catalog,
+    is_night_assignment,
+    requires_next_day_rest,
+)
 from solver.engine import generate_planning as generate_planning_engine
 
 app = Flask(__name__)
@@ -568,8 +573,29 @@ def _build_suggestions_from_context(manual_entries, warnings, unsat_reason=None,
         if reason.get("code") not in {"GLOBAL_UNSAT", "PREVALIDATION_WARNINGS_PRESENT"}
     ]
     if unsat_reason is not None and manual_entries and actionable_reasons:
-        first = manual_entries[0]
         first_reason = actionable_reasons[0]
+        actionable_segments = [
+            segment
+            for segment in first_reason.get("segments", [])
+            if "clear_cell" in (segment.get("actions") or [])
+            and segment.get("agent")
+            and segment.get("date")
+        ]
+        if actionable_segments:
+            for segment in actionable_segments:
+                suggestions.append(
+                    {
+                        "agent": segment.get("agent"),
+                        "date": segment.get("date"),
+                        "slot": segment.get("slot", "day"),
+                        "reason_code": first_reason.get("code", "GLOBAL_UNSAT"),
+                        "message": first_reason.get("message", unsat_reason),
+                        "proposals": [{"action": "clear_cell"}],
+                    }
+                )
+            return suggestions
+
+        first = manual_entries[0]
         suggestions.append(
             {
                 "agent": first.get("agent"),
@@ -618,6 +644,32 @@ def _date_matches_vacation_period(iso_date, vacation_periods):
         if start_dt <= day_dt <= end_dt:
             return True
     return False
+
+
+def _manual_conflict_segment(entry, blocker, label, extra=None):
+    segment = {
+        "agent": entry.get("agent"),
+        "date": entry.get("date"),
+        "slot": entry.get("slot", "day"),
+        "value": entry.get("value"),
+        "vacation": entry.get("value"),
+        "segment": label,
+        "blockers": {blocker: 1},
+        "actions": ["clear_cell"],
+    }
+    if extra:
+        segment.update(extra)
+    return segment
+
+
+def _manual_conflict_details(segments):
+    return [
+        (
+            f"{segment.get('agent')} - {segment.get('date')} - "
+            f"{segment.get('value')}: {segment.get('segment')}"
+        )
+        for segment in segments
+    ]
 
 
 def _agent_has_status_on_day(agent, iso_date):
@@ -1069,6 +1121,7 @@ def _probe_relaxed_hard_constraints(planning_payload, runtime_config):
 def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
     reasons = []
     by_agent = {agent["name"]: agent for agent in runtime_config.get("agents", [])}
+    catalog = build_vacation_catalog(runtime_config)
     (
         manual_shifts_by_agent_day,
         manual_counts_by_day_shift,
@@ -1081,6 +1134,10 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
     training_conflicts = 0
     restriction_conflicts = 0
     vacation_conflicts = 0
+    unavailable_segments = []
+    training_segments = []
+    restriction_segments = []
+    vacation_segments = []
 
     for entry in manual_entries:
         if entry.get("type") != "shift":
@@ -1101,12 +1158,34 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
 
         if day_str in (agent.get("unavailable") or []):
             unavailable_conflicts += 1
+            unavailable_segments.append(
+                _manual_conflict_segment(entry, "status", "indisponibilité")
+            )
         if day_str in (agent.get("training") or []):
             training_conflicts += 1
-        if shift_value in (agent.get("restriction") or []):
+            training_segments.append(
+                _manual_conflict_segment(entry, "status", "formation")
+            )
+        matching_restrictions = [
+            restriction
+            for restriction in (agent.get("restriction") or [])
+            if assignment_matches_choice(catalog, shift_value, {restriction})
+        ]
+        if matching_restrictions:
             restriction_conflicts += 1
+            restriction_segments.append(
+                _manual_conflict_segment(
+                    entry,
+                    "restriction",
+                    ", ".join(matching_restrictions),
+                    {"restriction": matching_restrictions[0]},
+                )
+            )
         if _date_matches_vacation_period(iso_date, agent.get("vacations") or []):
             vacation_conflicts += 1
+            vacation_segments.append(
+                _manual_conflict_segment(entry, "status", "congés")
+            )
 
     if duplicate_count:
         reasons.append(
@@ -1122,6 +1201,8 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
                 "code": "MANUAL_SHIFT_ON_UNAVAILABLE_DAY",
                 "message": "Une vacation manuelle a été posée sur un jour d'indisponibilité.",
                 "count": unavailable_conflicts,
+                "details": _manual_conflict_details(unavailable_segments),
+                "segments": unavailable_segments,
             }
         )
     if training_conflicts:
@@ -1130,6 +1211,8 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
                 "code": "MANUAL_SHIFT_ON_TRAINING_DAY",
                 "message": "Une vacation manuelle a été posée sur un jour de formation.",
                 "count": training_conflicts,
+                "details": _manual_conflict_details(training_segments),
+                "segments": training_segments,
             }
         )
     if vacation_conflicts:
@@ -1138,6 +1221,8 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
                 "code": "MANUAL_SHIFT_DURING_VACATION",
                 "message": "Une vacation manuelle a été posée pendant une période de congé.",
                 "count": vacation_conflicts,
+                "details": _manual_conflict_details(vacation_segments),
+                "segments": vacation_segments,
             }
         )
     if restriction_conflicts:
@@ -1146,6 +1231,8 @@ def _diagnose_manual_entry_conflicts(manual_entries, runtime_config):
                 "code": "MANUAL_SHIFT_MATCHES_AGENT_RESTRICTION",
                 "message": "Une vacation manuelle correspond à une restriction agent.",
                 "count": restriction_conflicts,
+                "details": _manual_conflict_details(restriction_segments),
+                "segments": restriction_segments,
             }
         )
 

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -601,6 +601,75 @@ def test_diagnose_manual_entry_conflicts_detects_manual_overstaffing():
     assert "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT" in reason_codes
 
 
+def test_diagnose_manual_entry_conflicts_reports_restricted_manual_cell():
+    config = deepcopy(load_default_config())
+    agent = config["agents"][0]
+    agent["restriction"] = ["Jour"]
+
+    reasons = _diagnose_manual_entry_conflicts(
+        [
+            {
+                "agent": agent["name"],
+                "date": "2026-01-15",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            }
+        ],
+        config,
+    )
+
+    restriction_reason = next(
+        reason
+        for reason in reasons
+        if reason["code"] == "MANUAL_SHIFT_MATCHES_AGENT_RESTRICTION"
+    )
+    assert restriction_reason["count"] == 1
+    assert restriction_reason["segments"] == [
+        {
+            "agent": agent["name"],
+            "date": "2026-01-15",
+            "slot": "day",
+            "value": "Jour",
+            "vacation": "Jour",
+            "segment": "Jour",
+            "blockers": {"restriction": 1},
+            "actions": ["clear_cell"],
+            "restriction": "Jour",
+        }
+    ]
+
+
+def test_diagnose_manual_entry_conflicts_detects_parent_restriction_for_half_shift():
+    config = deepcopy(load_default_config())
+    agent = config["agents"][0]
+    agent["restriction"] = ["Jour"]
+
+    reasons = _diagnose_manual_entry_conflicts(
+        [
+            {
+                "agent": agent["name"],
+                "date": "2026-01-15",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour après-midi",
+            }
+        ],
+        config,
+    )
+
+    restriction_reason = next(
+        reason
+        for reason in reasons
+        if reason["code"] == "MANUAL_SHIFT_MATCHES_AGENT_RESTRICTION"
+    )
+    assert restriction_reason["count"] == 1
+    assert restriction_reason["segments"][0]["agent"] == agent["name"]
+    assert restriction_reason["segments"][0]["date"] == "2026-01-15"
+    assert restriction_reason["segments"][0]["value"] == "Jour après-midi"
+    assert restriction_reason["segments"][0]["restriction"] == "Jour"
+
+
 def test_diagnose_manual_entry_conflicts_does_not_emit_day_shift_weekly_quota():
     config = deepcopy(load_default_config())
     agent_name = config["agents"][0]["name"]
@@ -878,6 +947,52 @@ def test_optimize_existing_planning_unsat_omits_manual_reason_when_specific_diag
     assert "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT" in reason_codes
     assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" not in reason_codes
     assert payload["suggestions"][0]["reason_code"] == "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT"
+
+
+def test_optimize_existing_planning_suggests_actual_restricted_manual_cell(client):
+    config = deepcopy(load_default_config())
+    config["agents"] = config["agents"][:2]
+    first_agent = config["agents"][0]
+    restricted_agent = config["agents"][1]
+    for agent in config["agents"]:
+        agent["unavailable"] = []
+        agent["training"] = []
+        agent["vacations"] = []
+        agent["restriction"] = []
+    restricted_agent["restriction"] = ["Jour"]
+    set_active_config(config)
+
+    data = {
+        "start_date": "2026-01-15",
+        "end_date": "2026-01-15",
+        "manual_entries": [
+            {
+                "agent": first_agent["name"],
+                "date": "2026-01-15",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            },
+            {
+                "agent": restricted_agent["name"],
+                "date": "2026-01-15",
+                "slot": "day",
+                "type": "shift",
+                "value": "Jour",
+            },
+        ],
+    }
+
+    with patch("app._build_planning_payload", return_value=({"info": "No solution found."}, 400)):
+        response = client.post(
+            "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+        )
+
+    payload = response.get_json()
+    assert payload["suggestions"][0]["reason_code"] == "MANUAL_SHIFT_MATCHES_AGENT_RESTRICTION"
+    assert payload["suggestions"][0]["agent"] == restricted_agent["name"]
+    assert payload["suggestions"][0]["date"] == "2026-01-15"
+    assert payload["suggestions"][0]["agent"] != first_agent["name"]
 
 
 def test_optimize_existing_planning_rejects_unknown_status_value(client):


### PR DESCRIPTION
## Summary

- Fixes manual restriction diagnostics so `MANUAL_SHIFT_MATCHES_AGENT_RESTRICTION` is attached to the actual conflicting manual cell.
- Reuses the solver assignment matching semantics, so parent restrictions such as `Jour` also apply to half-vacations like `Jour matin` and `Jour après-midi`.
- Adds actionable diagnostic segments and details for direct manual conflicts.
- Updates unsat suggestions to clear the real conflicting cell instead of defaulting to the first manual entry.
- Adds regression coverage for direct restrictions, parent restrictions, and route-level suggestion targeting.

## Tests

- `.\.venv\Scripts\python -m pytest backend\tests\test_routes.py`
- `.\.venv\Scripts\python -m pytest backend\tests`