### PR TITLE
Improve manual assignment impact diagnostics for infeasible schedules

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -567,10 +567,16 @@ def _build_suggestions_from_context(manual_entries, warnings, unsat_reason=None,
     if suggestions:
         return suggestions
 
+    non_actionable_reason_codes = {
+        "GLOBAL_UNSAT",
+        "GLOBAL_UNSAT_WITHOUT_MANUAL_LOCKS",
+        "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN",
+        "PREVALIDATION_WARNINGS_PRESENT",
+    }
     actionable_reasons = [
         reason
         for reason in (blocking_reasons or [])
-        if reason.get("code") not in {"GLOBAL_UNSAT", "PREVALIDATION_WARNINGS_PRESENT"}
+        if reason.get("code") not in non_actionable_reason_codes
     ]
     if unsat_reason is not None and manual_entries and actionable_reasons:
         first_reason = actionable_reasons[0]
@@ -594,18 +600,6 @@ def _build_suggestions_from_context(manual_entries, warnings, unsat_reason=None,
                     }
                 )
             return suggestions
-
-        first = manual_entries[0]
-        suggestions.append(
-            {
-                "agent": first.get("agent"),
-                "date": first.get("date"),
-                "slot": first.get("slot", "day"),
-                "reason_code": first_reason.get("code", "GLOBAL_UNSAT"),
-                "message": first_reason.get("message", unsat_reason),
-                "proposals": [{"action": "clear_cell"}],
-            }
-        )
     return suggestions
 
 
@@ -622,6 +616,137 @@ def _build_blocking_reasons_from_context(manual_entries, warnings, unsat_reason)
             }
         )
     return reasons
+
+
+def _manual_entries_to_initial_shifts(manual_entries):
+    initial_shifts = {}
+    for entry in manual_entries:
+        if entry.get("type") != "shift" or not is_valid_date(entry.get("date")):
+            continue
+        agent = entry.get("agent")
+        value = entry.get("value")
+        if not agent or not value:
+            continue
+        entry_date = datetime.strptime(entry["date"], "%Y-%m-%d")
+        initial_shifts.setdefault(agent, []).append((format_day_label(entry_date), value))
+    return initial_shifts
+
+
+def _manual_lock_segment(entry, label):
+    return {
+        "agent": entry.get("agent"),
+        "date": entry.get("date"),
+        "slot": entry.get("slot", "day"),
+        "value": entry.get("value"),
+        "vacation": entry.get("value"),
+        "segment": label,
+        "actions": ["clear_cell"],
+    }
+
+
+def _diagnose_manual_lock_impact(planning_payload, manual_entries, runtime_config):
+    manual_shift_entries = [
+        entry
+        for entry in manual_entries
+        if entry.get("type") == "shift" and is_valid_date(entry.get("date"))
+    ]
+    if not manual_shift_entries:
+        return []
+
+    unlocked_payload = deepcopy(planning_payload)
+    unlocked_payload["initial_shifts"] = {}
+    _, unlocked_status_code = _build_planning_payload(
+        payload=unlocked_payload,
+        runtime_config=runtime_config,
+    )
+    if unlocked_status_code != 200:
+        return [
+            {
+                "code": "GLOBAL_UNSAT_WITHOUT_MANUAL_LOCKS",
+                "message": (
+                    "Le planning reste infaisable meme sans verrouiller les cellules "
+                    "manuelles. Le blocage ne vient donc pas uniquement de ces verrous."
+                ),
+                "count": 1,
+            }
+        ]
+
+    isolated_segments = []
+    for entry in manual_shift_entries:
+        single_payload = deepcopy(planning_payload)
+        single_payload["initial_shifts"] = _manual_entries_to_initial_shifts([entry])
+        _, single_status_code = _build_planning_payload(
+            payload=single_payload,
+            runtime_config=runtime_config,
+        )
+        if single_status_code != 200:
+            isolated_segments.append(_manual_lock_segment(entry, "cellule manuelle"))
+
+    if isolated_segments:
+        return [
+            {
+                "code": "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT",
+                "message": (
+                    "Une ou plusieurs cellules manuelles, sans contradiction directe "
+                    "apparente, rendent le planning infaisable lorsqu'elles sont verrouillees."
+                ),
+                "count": len(isolated_segments),
+                "details": [
+                    f"{segment['agent']} - {segment['date']} - {segment['value']}"
+                    for segment in isolated_segments[:5]
+                ],
+                "segments": isolated_segments[:5],
+            }
+        ]
+
+    entries_by_date = {}
+    for entry in manual_shift_entries:
+        entries_by_date.setdefault(entry.get("date"), []).append(entry)
+
+    date_segments = []
+    for iso_date, entries in sorted(entries_by_date.items()):
+        if len(entries) <= 1:
+            continue
+        date_payload = deepcopy(planning_payload)
+        date_payload["initial_shifts"] = _manual_entries_to_initial_shifts(entries)
+        _, date_status_code = _build_planning_payload(
+            payload=date_payload,
+            runtime_config=runtime_config,
+        )
+        if date_status_code != 200:
+            date_segments.extend(
+                _manual_lock_segment(entry, f"combinaison du {iso_date}")
+                for entry in entries
+            )
+
+    if date_segments:
+        return [
+            {
+                "code": "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT",
+                "message": (
+                    "Les cellules manuelles d'une meme date ne violent pas directement "
+                    "une regle, mais leur verrouillage rend le planning infaisable."
+                ),
+                "count": len(date_segments),
+                "details": [
+                    f"{segment['agent']} - {segment['date']} - {segment['value']}"
+                    for segment in date_segments[:5]
+                ],
+                "segments": date_segments[:5],
+            }
+        ]
+
+    return [
+        {
+            "code": "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT",
+            "message": (
+                "Aucune contradiction directe n'a ete detectee sur les cellules "
+                "manuelles. Le planning est faisable sans les verrouiller, mais "
+                "leur combinaison complete rend le modele infaisable."
+            ),
+            "count": len(manual_shift_entries),
+        }
+    ]
 
 
 def _date_matches_vacation_period(iso_date, vacation_periods):
@@ -1332,6 +1457,19 @@ def optimize_existing_planning_route():
             )
             if relaxed_constraint_reasons:
                 blocking_reasons.extend(relaxed_constraint_reasons)
+            elif manual_entries and existing_assignments_strict:
+                manual_lock_reasons = _diagnose_manual_lock_impact(
+                    planning_payload={
+                        "start_date": payload["start_date"],
+                        "end_date": payload["end_date"],
+                        "initial_shifts": existing_assignments,
+                        "existing_assignments": existing_assignments,
+                    },
+                    manual_entries=manual_entries,
+                    runtime_config=effective_runtime_config,
+                )
+                if manual_lock_reasons:
+                    blocking_reasons.extend(manual_lock_reasons)
             elif manual_entries:
                 blocking_reasons.append(
                     {

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -506,7 +506,7 @@ def test_optimize_existing_planning_unsat_returns_blocking_reasons_and_suggestio
     payload = response.get_json()
     assert payload["status"] == "unsat"
     assert payload["blocking_reasons"] != []
-    assert payload["suggestions"] != []
+    assert payload["suggestions"] == []
 
 
 def test_diagnose_manual_entry_conflicts_detects_unavailable_day():
@@ -841,7 +841,7 @@ def test_optimize_existing_planning_unsat_uses_relaxed_constraint_diagnostics(cl
     assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" not in reason_codes
 
 
-def test_optimize_existing_planning_unsat_returns_unknown_manual_impact_without_specific_diagnostic(client):
+def test_optimize_existing_planning_unsat_detects_global_unsat_without_manual_locks(client):
     config = deepcopy(load_default_config())
     agent = config["agents"][0]
     agent_name = agent["name"]
@@ -871,12 +871,13 @@ def test_optimize_existing_planning_unsat_returns_unknown_manual_impact_without_
     payload = response.get_json()
     reason_codes = [reason["code"] for reason in payload["blocking_reasons"]]
     assert "GLOBAL_UNSAT" in reason_codes
-    assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" in reason_codes
-    assert "MANUAL_ASSIGNMENTS_CONFLICT_POSSIBLE" not in reason_codes
-    assert payload["suggestions"] != []
+    assert "GLOBAL_UNSAT_WITHOUT_MANUAL_LOCKS" in reason_codes
+    assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" not in reason_codes
+    assert "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT" not in reason_codes
+    assert payload["suggestions"] == []
 
 
-def test_optimize_existing_planning_unsat_returns_generic_blocking_reasons(client):
+def test_optimize_existing_planning_unsat_detects_manual_lock_impact(client):
     config = deepcopy(load_default_config())
     agent_name = config["agents"][0]["name"]
     set_active_config(config)
@@ -893,7 +894,13 @@ def test_optimize_existing_planning_unsat_returns_generic_blocking_reasons(clien
             }
         ],
     }
-    with patch("app._build_planning_payload", return_value=({"info": "No solution found."}, 400)):
+
+    def planning_payload_side_effect(payload, runtime_config):
+        if payload.get("initial_shifts"):
+            return {"info": "No solution found."}, 400
+        return {"planning": {agent_name: []}, "week_schedule": ["Ven. 16-01"]}, 200
+
+    with patch("app._build_planning_payload", side_effect=planning_payload_side_effect):
         response = client.post(
             "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
         )
@@ -901,9 +908,70 @@ def test_optimize_existing_planning_unsat_returns_generic_blocking_reasons(clien
     payload = response.get_json()
     reason_codes = [reason["code"] for reason in payload["blocking_reasons"]]
     assert "GLOBAL_UNSAT" in reason_codes
-    assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" in reason_codes
-    assert "MANUAL_ASSIGNMENTS_CONFLICT_POSSIBLE" not in reason_codes
-    assert payload["suggestions"] != []
+    assert "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT" in reason_codes
+    assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" not in reason_codes
+    assert payload["suggestions"][0]["reason_code"] == "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT"
+    assert payload["suggestions"][0]["agent"] == agent_name
+    assert payload["suggestions"][0]["date"] == "2026-01-16"
+
+
+def test_optimize_existing_planning_unsat_detects_manual_lock_date_group(client):
+    config = deepcopy(load_default_config())
+    config["agents"] = config["agents"][:2]
+    config["vacations"] = ["Jour", "Nuit"]
+    config["staffing_requirements"] = {"Jour": 1, "Nuit": 1}
+    for agent in config["agents"]:
+        agent["unavailable"] = []
+        agent["training"] = []
+        agent["vacations"] = []
+        agent["restriction"] = []
+    first_agent = config["agents"][0]["name"]
+    second_agent = config["agents"][1]["name"]
+    set_active_config(config)
+    data = {
+        "start_date": "2026-01-16",
+        "end_date": "2026-01-16",
+        "manual_entries": [
+            {
+                "agent": first_agent,
+                "date": "2026-01-16",
+                "slot": "day",
+                "type": "shift",
+                "value": config["vacations"][0],
+            },
+            {
+                "agent": second_agent,
+                "date": "2026-01-16",
+                "slot": "night",
+                "type": "shift",
+                "value": config["vacations"][1],
+            },
+        ],
+    }
+
+    def planning_payload_side_effect(payload, runtime_config):
+        lock_count = sum(len(shifts) for shifts in payload.get("initial_shifts", {}).values())
+        if lock_count > 1:
+            return {"info": "No solution found."}, 400
+        return {"planning": {first_agent: [], second_agent: []}, "week_schedule": ["Ven. 16-01"]}, 200
+
+    with patch("app._build_planning_payload", side_effect=planning_payload_side_effect):
+        response = client.post(
+            "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
+        )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    lock_reason = next(
+        reason
+        for reason in payload["blocking_reasons"]
+        if reason["code"] == "MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT"
+    )
+    assert lock_reason["count"] == 2
+    assert {suggestion["agent"] for suggestion in payload["suggestions"]} == {
+        first_agent,
+        second_agent,
+    }
 
 
 def test_optimize_existing_planning_unsat_omits_manual_reason_when_specific_diagnostic_exists(client):
@@ -937,7 +1005,10 @@ def test_optimize_existing_planning_unsat_omits_manual_reason_when_specific_diag
             },
         ],
     }
-    with patch("app._build_planning_payload", return_value=({"info": "No solution found."}, 400)):
+    with (
+        patch("app._build_planning_payload", return_value=({"info": "No solution found."}, 400)),
+        patch("app._diagnose_manual_lock_impact") as diagnose_manual_lock_impact,
+    ):
         response = client.post(
             "/optimize-existing-planning", data=json.dumps(data), content_type="application/json"
         )
@@ -946,7 +1017,8 @@ def test_optimize_existing_planning_unsat_omits_manual_reason_when_specific_diag
     reason_codes = [reason["code"] for reason in payload["blocking_reasons"]]
     assert "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT" in reason_codes
     assert "MANUAL_ASSIGNMENTS_IMPACT_UNKNOWN" not in reason_codes
-    assert payload["suggestions"][0]["reason_code"] == "MANUAL_SHIFT_EXCEEDS_STAFFING_REQUIREMENT"
+    assert payload["suggestions"] == []
+    diagnose_manual_lock_impact.assert_not_called()
 
 
 def test_optimize_existing_planning_suggests_actual_restricted_manual_cell(client):


### PR DESCRIPTION
## Summary

- Adds comparative diagnostics to distinguish schedules that remain infeasible without manual locks from schedules made infeasible by strict manual assignments.
- Introduces `GLOBAL_UNSAT_WITHOUT_MANUAL_LOCKS` when the global constraints are already infeasible without locked assignments.
- Introduces `MANUAL_ASSIGNMENTS_LOCK_COMBINATION_UNSAT` when manual locks make an otherwise feasible schedule infeasible.
- Attempts to isolate blocking individual cells or same-date assignment groups.
- Stops suggesting that the first manual cell be cleared when no actionable cell has been identified.
- Adds regression coverage for global infeasibility, individual lock impact, grouped lock impact, and existing specific diagnostics.

## Tests

- `.\.venv\Scripts\python.exe -m pytest backend\tests\test_routes.py -q`
  - `50 passed`
- `.\.venv\Scripts\python.exe -m pytest backend\tests -q`
  - `134 passed`