### PR TITLE
Allow agents to opt out of paid-hours balance

### DIFF
--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -2,6 +2,7 @@
   "agents": [
     {
       "name": "Agent1",
+      "include_in_balance": true,
       "preferences": {
         "preferred": [
           "Jour",

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -152,6 +152,9 @@
           "type": "string",
           "minLength": 1
         },
+        "include_in_balance": {
+          "type": "boolean"
+        },
         "preferences": {
           "type": "object",
           "additionalProperties": false,

--- a/backend/solver/constraints/soft.py
+++ b/backend/solver/constraints/soft.py
@@ -84,8 +84,12 @@ def balance_paid_hours(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
+    balanced_agents = _agents_in_paid_hours_balance(ctx)
+    if len(balanced_agents) < 2:
+        return
+
     paid_hours = {}
-    for agent in ctx.agents:
+    for agent in balanced_agents:
         agent_name = agent["name"]
         paid_hours[agent_name] = cp_model.LinearExpr.Sum(
             list(
@@ -119,12 +123,17 @@ def balance_paid_hours_by_period(ctx: SolverContext) -> None:
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
     """
+    balanced_agents = _agents_in_paid_hours_balance(ctx)
+    if len(balanced_agents) < 2:
+        ctx.period_balancing_objective = 0
+        return
+
     periods = split_by_month_or_period(ctx.week_schedule)
 
     period_balancing_terms = []
     for period_idx, period in enumerate(periods):
         period_total_hours = {}
-        for agent in ctx.agents:
+        for agent in balanced_agents:
             agent_name = agent["name"]
             period_total_hours[agent_name] = cp_model.LinearExpr.Sum(
                 list(
@@ -139,7 +148,7 @@ def balance_paid_hours_by_period(ctx: SolverContext) -> None:
 
         min_period_hours = ctx.model.NewIntVar(0, 100000, f"min_hours_period_{period_idx}")
         max_period_hours = ctx.model.NewIntVar(0, 100000, f"max_hours_period_{period_idx}")
-        for agent in ctx.agents:
+        for agent in balanced_agents:
             agent_name = agent["name"]
             ctx.model.Add(min_period_hours <= period_total_hours[agent_name])
             ctx.model.Add(period_total_hours[agent_name] <= max_period_hours)

--- a/backend/solver/constraints/soft.py
+++ b/backend/solver/constraints/soft.py
@@ -8,6 +8,11 @@ from ..utils import split_by_month_or_period
 CDP_SHIFT = "CDP"
 
 
+def _agents_in_paid_hours_balance(ctx: SolverContext) -> list[dict]:
+    """Return agents participating in paid-hours balance constraints."""
+    return [agent for agent in ctx.agents if agent.get("include_in_balance", True)]
+
+
 def _assignment_sum(ctx: SolverContext, agent_name: str, day: str, vacations: list[str]) -> int:
     """
     Computes the sum of assignments for a given agent, day, and list of vacations.

--- a/backend/tests/test_config_schema.py
+++ b/backend/tests/test_config_schema.py
@@ -87,6 +87,31 @@ def test_schema_accepts_max_weekly_hours():
     assert errors == []
 
 
+def test_schema_accepts_agent_balance_opt_out():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["agents"][0]["include_in_balance"] = False
+    validator = Draft202012Validator(schema)
+
+    assert list(validator.iter_errors(example)) == []
+
+
+def test_schema_rejects_non_boolean_agent_balance_opt_out():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+
+    example["agents"][0]["include_in_balance"] = "false"
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors != []
+    assert any(
+        "include_in_balance" in "/".join(str(part) for part in error.path)
+        for error in errors
+    )
+
+
 def test_schema_accepts_temporal_vacation_metadata():
     schema = _load_json(SCHEMA_PATH)
     example = _load_json(EXAMPLE_PATH)

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -7,6 +7,40 @@ from ortools.sat.python import cp_model
 from app import generate_planning, get_active_config, load_default_config, set_active_config
 from solver.catalog import AssignmentMetadata
 from solver.constraints.mixed import limit_weekly_nights_and_hours
+from solver.constraints.soft import balance_paid_hours, balance_paid_hours_by_period
+
+
+def _solve_forced_paid_hours_balance(agents, apply_global=True, apply_period=True):
+    model = cp_model.CpModel()
+    day = "Lun. 01-06"
+    planning = {
+        (agent["name"], day, "Jour"): model.NewBoolVar(
+            f"planning_{agent['name']}_{day}_Jour"
+        )
+        for agent in agents
+    }
+    ctx = SimpleNamespace(
+        agents=agents,
+        assignable_vacations=["Jour"],
+        week_schedule=[day],
+        planning=planning,
+        shift_durations={"Jour": 120},
+        leave_paid_hours_by_day={},
+        global_max_gap=0,
+        period_max_gap=0,
+        model=model,
+        period_balancing_objective=0,
+    )
+
+    if apply_global:
+        balance_paid_hours(ctx)
+    if apply_period:
+        balance_paid_hours_by_period(ctx)
+
+    for index, agent in enumerate(agents):
+        model.Add(planning[(agent["name"], day, "Jour")] == int(index < 2))
+
+    return cp_model.CpSolver().Solve(model)
 
 
 def _solve_forced_weekly_shifts(max_weekly_hours):
@@ -115,6 +149,135 @@ def _solve_forced_temporal_weekly_shifts(max_weekly_hours):
 
     solver = cp_model.CpSolver()
     return solver.Solve(model)
+
+
+def test_paid_hours_balance_includes_agents_by_default():
+    agents = [{"name": "Agent1"}, {"name": "Agent2"}, {"name": "Agent3"}]
+
+    status = _solve_forced_paid_hours_balance(agents)
+
+    assert status == cp_model.INFEASIBLE
+
+
+def test_paid_hours_balance_ignores_opted_out_agent_with_zero_hours():
+    agents = [
+        {"name": "Agent1"},
+        {"name": "Agent2"},
+        {"name": "Occasional", "include_in_balance": False},
+    ]
+
+    status = _solve_forced_paid_hours_balance(agents)
+
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+
+def test_period_paid_hours_balance_ignores_opted_out_agent():
+    agents = [
+        {"name": "Agent1"},
+        {"name": "Agent2"},
+        {"name": "Occasional", "include_in_balance": False},
+    ]
+
+    status = _solve_forced_paid_hours_balance(
+        agents, apply_global=False, apply_period=True
+    )
+
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+
+def test_paid_hours_balance_is_skipped_with_fewer_than_two_included_agents():
+    agents = [
+        {"name": "Permanent"},
+        {"name": "Occasional", "include_in_balance": False},
+    ]
+
+    status = _solve_forced_paid_hours_balance(agents)
+
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+
+def test_opted_out_agent_remains_subject_to_weekly_hour_limit():
+    model = cp_model.CpModel()
+    agent = {"name": "Occasional", "include_in_balance": False}
+    week = ["Lun. 01-06", "Mar. 02-06"]
+    planning = {
+        (agent["name"], day, "Jour"): model.NewBoolVar(f"planning_{day}")
+        for day in week
+    }
+    ctx = SimpleNamespace(
+        agents=[agent],
+        vacations=["Jour"],
+        assignable_vacations=["Jour"],
+        weeks_split=[week],
+        week_schedule=week,
+        planning=planning,
+        day_dates={},
+        assignment_metadata={},
+        shift_durations={"Jour": 120},
+        max_weekly_hours=120,
+        model=model,
+    )
+
+    limit_weekly_nights_and_hours(ctx)
+    for day in week:
+        model.Add(planning[(agent["name"], day, "Jour")] == 1)
+
+    assert cp_model.CpSolver().Solve(model) == cp_model.INFEASIBLE
+
+
+def test_opted_out_agent_keeps_locked_manual_shift():
+    agents = [
+        {
+            "name": "Permanent",
+            "include_in_balance": True,
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+        {
+            "name": "Occasional",
+            "include_in_balance": False,
+            "unavailable": [],
+            "training": [],
+            "preferences": {"preferred": ["Jour"], "avoid": []},
+            "vacations": [],
+            "restriction": [],
+            "exclusion": [],
+        },
+    ]
+    day = "Lun. 01-06"
+
+    result = generate_planning(
+        agents=agents,
+        vacations=["Jour"],
+        week_schedule=[day],
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={"Occasional": [(day, "Jour")]},
+        planning_start_date="2026-06-01",
+        runtime_config={
+            "vacation_durations": {"Jour": 12, "Conge": 7},
+            "staffing_requirements": {"Jour": 1},
+            "holidays": [],
+            "solver": {
+                "max_time_seconds": 30,
+                "relative_gap_limit": 0.1,
+                "num_search_workers": 0,
+                "global_max_gap": 0,
+                "period_max_gap": 0,
+                "max_weekly_hours": 12,
+                "optimize_period_balance": False,
+                "period_balance_weight": 2,
+                "min_free_weekends_per_horizon": 0,
+            },
+        },
+    )
+
+    assert "info" not in result
+    assert result["Occasional"] == [(day, "Jour")]
 
 
 @pytest.fixture(autouse=True)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -27,6 +27,10 @@ For machine validation, use:
 Agent object fields:
 
 - `name` (string, required): unique agent identifier.
+- `include_in_balance` (boolean, optional, default `true`): include the agent in
+  global and per-period paid-hour gap calculations. Set it to `false` for an
+  occasional agent whose workload must not affect team balance. This does not
+  disable coverage, availability, leave, restriction, rest, or weekly-hour rules.
 - `preferences` (object, required):
   - `preferred` (array of shifts)
   - `avoid` (array of shifts)


### PR DESCRIPTION
## Objective

Allow occasional agents to be excluded from paid-hours balancing without removing them from scheduling or relaxing other solver constraints.

## Breaking Change Notice

No API breaking change.

Existing configurations keep their current behavior because `include_in_balance` defaults to `true`.

## Scope

- Add optional agent configuration field `include_in_balance`.
- Exclude agents marked with `include_in_balance: false` from:
  - global paid-hours gap calculations
  - per-period paid-hours gap calculations
- Skip balance constraints cleanly when fewer than two agents participate.
- Preserve all other behavior for excluded agents:
  - shift coverage
  - locked manual assignments
  - availability, leave and training rules
  - restrictions and rest rules
  - weekly worked-hours cap
- Extend the configuration schema and example.
- Document the new agent-level option.
- Add focused solver and schema tests.

## Validation

- `backend/.venv/Scripts/python.exe -m pytest -q backend/tests`

## Results

- Backend test suite passes globally: `142/142` (`100%`).
- Agents remain included in paid-hours balancing by default.
- An opted-out agent with zero hours no longer affects team balance gaps.
- Locked manual assignments remain supported for opted-out agents.
- Weekly worked-hours limits remain enforced.
- Invalid non-boolean values are rejected by the configuration schema.

## Risks and Mitigations

- Risk: excluding an agent can hide a workload imbalance involving that agent.
- Mitigation: exclusion is explicit, agent-specific, and disabled by default.

- Risk: too few agents may remain available for meaningful balance calculations.
- Mitigation: global and per-period balance constraints are skipped when fewer than two agents participate.

## Notes

`backend/config.json` is local and ignored by Git. Runtime deployments must explicitly set `"include_in_balance": false` on the relevant occasional agents.