### PR TITLE
Soften weekend-to-Monday night sequence constraint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1197,11 +1197,6 @@ RELAXED_CONSTRAINT_DIAGNOSTICS = [
         "detail": "Relâcher les jours d'exclusion rendrait le planning faisable.",
     },
     {
-        "constraint": "block_monday_night_after_weekend_nights",
-        "label": "affectation de nuit du lundi après week-end",
-        "detail": "La règle d'affectation de nuit du lundi après des affectations de nuit de week-end semble bloquer une solution.",
-    },
-    {
         "constraint": "apply_agent_restrictions",
         "label": "restrictions agent",
         "detail": "Relâcher les restrictions agent rendrait le planning faisable.",

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -109,7 +109,8 @@
     "max_weekly_hours": 36,
     "optimize_period_balance": false,
     "period_balance_weight": 2,
-    "min_free_weekends_per_horizon": 3
+    "min_free_weekends_per_horizon": 3,
+    "weekend_monday_night_penalty": 500
   },
   "half_vacations": {
     "Jour": {

--- a/backend/config.schema.json
+++ b/backend/config.schema.json
@@ -103,6 +103,10 @@
         "min_free_weekends_per_horizon": {
           "type": "integer",
           "minimum": 0
+        },
+        "weekend_monday_night_penalty": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/backend/solver/constraints/hard.py
+++ b/backend/solver/constraints/hard.py
@@ -54,7 +54,6 @@ def register(registry: ConstraintRegistry) -> None:
     - Block night before training
     - Limit pre/post training
     - Block exclusion days
-    - Block Monday night after weekend nights
     - Apply agent restrictions
     """
     registry.register_hard(apply_initial_shifts)
@@ -71,7 +70,6 @@ def register(registry: ConstraintRegistry) -> None:
     registry.register_hard(block_night_before_training)
     registry.register_hard(limit_pre_post_training)
     registry.register_hard(block_exclusion_days)
-    registry.register_hard(block_monday_night_after_weekend_nights)
     registry.register_hard(apply_agent_restrictions)
 
 
@@ -493,35 +491,6 @@ def block_exclusion_days(ctx: SolverContext) -> None:
                     for vacation in ctx.assignable_vacations:
                         ctx.model.Add(ctx.planning[(agent_name, day_str, vacation)] == 0)
 
-
-def block_monday_night_after_weekend_nights(ctx: SolverContext) -> None:
-    """Blocks Monday night assignments after weekend night assignments."""
-    night_assignments = [
-        assignment for assignment in ctx.assignable_vacations if is_night_assignment(ctx, assignment)
-    ]
-    if not night_assignments:
-        return
-
-    for agent in ctx.agents:
-        agent_name = agent["name"]
-        for day_idx, day in enumerate(ctx.week_schedule[:-2]):
-            if "Sam" in day:
-                sunday_idx = day_idx + 1
-                monday_idx = day_idx + 2
-                if sunday_idx < len(ctx.week_schedule) and monday_idx < len(ctx.week_schedule):
-                    sunday = ctx.week_schedule[sunday_idx]
-                    monday = ctx.week_schedule[monday_idx]
-                    for saturday_assignment in night_assignments:
-                        for sunday_assignment in night_assignments:
-                            for monday_assignment in night_assignments:
-                                ctx.model.Add(
-                                    ctx.planning[(agent_name, monday, monday_assignment)] == 0
-                                ).OnlyEnforceIf(
-                                    [
-                                        ctx.planning[(agent_name, day, saturday_assignment)],
-                                        ctx.planning[(agent_name, sunday, sunday_assignment)],
-                                    ]
-                                )
 
 def apply_agent_restrictions(ctx: SolverContext) -> None:
     """Applies agent-specific vacation/assignment restrictions."""

--- a/backend/solver/constraints/soft.py
+++ b/backend/solver/constraints/soft.py
@@ -1,6 +1,6 @@
 from ortools.sat.python import cp_model
 
-from ..catalog import assignment_parent
+from ..catalog import assignment_parent, is_night_assignment
 from ..context import SolverContext
 from ..registry import ConstraintRegistry
 from ..utils import split_by_month_or_period
@@ -65,6 +65,7 @@ def register(registry: ConstraintRegistry) -> None:
     - balance_paid_hours: Balances paid hours across all agents in the week's schedule.
     - balance_paid_hours_by_period: Balances paid hours across all agents in each period of the week's schedule.
     - balance_full_weekends: Balances full weekends across all agents in the week's schedule.
+    - penalize_weekend_monday_nights: Penalizes Saturday/Sunday/Monday night sequences.
 
     :param registry: The constraint registry to which the constraints are registered.
     :type registry: ConstraintRegistry
@@ -72,6 +73,49 @@ def register(registry: ConstraintRegistry) -> None:
     registry.register_soft(balance_paid_hours)
     registry.register_soft(balance_paid_hours_by_period)
     registry.register_soft(balance_full_weekends)
+    registry.register_soft(penalize_weekend_monday_nights)
+
+
+def penalize_weekend_monday_nights(ctx: SolverContext) -> None:
+    """Build the objective term for Saturday/Sunday/Monday night sequences."""
+    night_assignments = [
+        assignment
+        for assignment in ctx.assignable_vacations
+        if is_night_assignment(ctx, assignment)
+    ]
+    if not night_assignments or ctx.weekend_monday_night_penalty == 0:
+        ctx.weekend_monday_night_objective = 0
+        return
+
+    sequence_terms = []
+    for agent in ctx.agents:
+        agent_name = agent["name"]
+        for day_idx, saturday in enumerate(ctx.week_schedule[:-2]):
+            sunday = ctx.week_schedule[day_idx + 1]
+            monday = ctx.week_schedule[day_idx + 2]
+            if not (
+                saturday.startswith("Sam")
+                and sunday.startswith("Dim")
+                and monday.startswith("Lun")
+            ):
+                continue
+
+            night_by_day = [
+                sum(
+                    ctx.planning[(agent_name, day, assignment)]
+                    for assignment in night_assignments
+                )
+                for day in (saturday, sunday, monday)
+            ]
+            sequence = ctx.model.NewBoolVar(
+                f"{agent_name}_weekend_monday_nights_{saturday}_{sunday}_{monday}"
+            )
+            for night_sum in night_by_day:
+                ctx.model.Add(sequence <= night_sum)
+            ctx.model.Add(sequence >= sum(night_by_day) - 2)
+            sequence_terms.append(sequence)
+
+    ctx.weekend_monday_night_objective = cp_model.LinearExpr.Sum(sequence_terms)
 
 
 def balance_paid_hours(ctx: SolverContext) -> None:

--- a/backend/solver/context.py
+++ b/backend/solver/context.py
@@ -45,9 +45,11 @@ class SolverContext:
         num_search_workers (int): Number of parallel search workers for the solver. Default: 0.
         optimize_period_balance (bool): Flag to enable period balancing optimization. Default: False.
         period_balance_weight (int): Weight factor for period balancing objectives. Default: 2.
+        weekend_monday_night_penalty (int): Penalty for Saturday/Sunday/Monday night sequences. Default: 500.
         
         period_balancing_objective (cp_model.LinearExpr | int): Objective expression for balancing workload across periods.
         weekend_balancing_objective (cp_model.LinearExpr | int): Objective expression for balancing weekend assignments.
+        weekend_monday_night_objective (cp_model.LinearExpr | int): Count of penalized night sequences.
     """
     model: cp_model.CpModel
     config: dict
@@ -84,6 +86,8 @@ class SolverContext:
     optimize_period_balance: bool = False
     period_balance_weight: int = 2
     min_free_weekends_per_horizon: int = 0
+    weekend_monday_night_penalty: int = 500
 
     period_balancing_objective: cp_model.LinearExpr | int = 0
     weekend_balancing_objective: cp_model.LinearExpr | int = 0
+    weekend_monday_night_objective: cp_model.LinearExpr | int = 0

--- a/backend/solver/engine.py
+++ b/backend/solver/engine.py
@@ -43,6 +43,7 @@ def _load_solver_settings(ctx: SolverContext) -> None:
     - optimize_period_balance: whether to optimize the period balance.
     - period_balance_weight: the weight of the period balance objective.
     - min_free_weekends_per_horizon: minimum number of fully free weekends required per agent.
+    - weekend_monday_night_penalty: objective penalty for three consecutive weekend/Monday nights.
 
     :param ctx: The solver context containing the problem data and the model.
     :type ctx: SolverContext
@@ -57,6 +58,9 @@ def _load_solver_settings(ctx: SolverContext) -> None:
     ctx.optimize_period_balance = bool(solver_config.get("optimize_period_balance", False))
     ctx.period_balance_weight = int(solver_config.get("period_balance_weight", 2))
     ctx.min_free_weekends_per_horizon = int(solver_config.get("min_free_weekends_per_horizon", 0))
+    ctx.weekend_monday_night_penalty = int(
+        solver_config.get("weekend_monday_night_penalty", 500)
+    )
 
 
 def _load_shift_durations(ctx: SolverContext) -> None:

--- a/backend/solver/objective.py
+++ b/backend/solver/objective.py
@@ -106,6 +106,7 @@ def apply_objective(ctx: SolverContext) -> None:
         - half_vacation_penalties
         - cp_model.LinearExpr.Sum(change_existing_assignments)
         - ctx.weekend_balancing_objective
+        - ctx.weekend_monday_night_penalty * ctx.weekend_monday_night_objective
     )
     if ctx.optimize_period_balance:
         objective -= ctx.period_balance_weight * ctx.period_balancing_objective

--- a/backend/tests/test_config_schema.py
+++ b/backend/tests/test_config_schema.py
@@ -87,6 +87,32 @@ def test_schema_accepts_max_weekly_hours():
     assert errors == []
 
 
+@pytest.mark.parametrize("penalty", [0, 500])
+def test_schema_accepts_weekend_monday_night_penalty(penalty):
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+    example["solver"]["weekend_monday_night_penalty"] = penalty
+
+    validator = Draft202012Validator(schema)
+
+    assert list(validator.iter_errors(example)) == []
+
+
+def test_schema_rejects_negative_weekend_monday_night_penalty():
+    schema = _load_json(SCHEMA_PATH)
+    example = _load_json(EXAMPLE_PATH)
+    example["solver"]["weekend_monday_night_penalty"] = -1
+
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(example))
+
+    assert errors != []
+    assert any(
+        "weekend_monday_night_penalty" in "/".join(str(part) for part in error.path)
+        for error in errors
+    )
+
+
 def test_schema_accepts_agent_balance_opt_out():
     schema = _load_json(SCHEMA_PATH)
     example = _load_json(EXAMPLE_PATH)

--- a/backend/tests/test_constraints.py
+++ b/backend/tests/test_constraints.py
@@ -7,7 +7,207 @@ from ortools.sat.python import cp_model
 from app import generate_planning, get_active_config, load_default_config, set_active_config
 from solver.catalog import AssignmentMetadata
 from solver.constraints.mixed import limit_weekly_nights_and_hours
-from solver.constraints.soft import balance_paid_hours, balance_paid_hours_by_period
+from solver.constraints.soft import (
+    balance_paid_hours,
+    balance_paid_hours_by_period,
+    penalize_weekend_monday_nights,
+)
+
+
+def _weekend_monday_night_context(agent_names, night_assignments=None, penalty=500):
+    model = cp_model.CpModel()
+    days = ["Sam. 10-01", "Dim. 11-01", "Lun. 12-01"]
+    assignments = night_assignments or ["Nuit"]
+    planning = {
+        (agent_name, day, assignment): model.NewBoolVar(
+            f"planning_{agent_name}_{day}_{assignment}"
+        )
+        for agent_name in agent_names
+        for day in days
+        for assignment in assignments
+    }
+    metadata = {
+        assignment: AssignmentMetadata(
+            name=assignment,
+            parent="Nuit",
+            duration=120,
+            is_night=True,
+        )
+        for assignment in assignments
+    }
+    ctx = SimpleNamespace(
+        agents=[{"name": agent_name} for agent_name in agent_names],
+        assignable_vacations=assignments,
+        assignment_metadata=metadata,
+        week_schedule=days,
+        planning=planning,
+        model=model,
+        weekend_monday_night_penalty=penalty,
+        weekend_monday_night_objective=0,
+    )
+    for agent_name in agent_names:
+        for day in days:
+            model.Add(
+                sum(planning[(agent_name, day, assignment)] for assignment in assignments)
+                <= 1
+            )
+    return ctx
+
+
+def test_weekend_monday_night_penalty_prefers_an_available_alternative():
+    ctx = _weekend_monday_night_context(["Weekend", "Monday"])
+    saturday, sunday, monday = ctx.week_schedule
+
+    ctx.model.Add(ctx.planning[("Weekend", saturday, "Nuit")] == 1)
+    ctx.model.Add(ctx.planning[("Weekend", sunday, "Nuit")] == 1)
+    ctx.model.Add(
+        ctx.planning[("Weekend", monday, "Nuit")]
+        + ctx.planning[("Monday", monday, "Nuit")]
+        == 1
+    )
+    penalize_weekend_monday_nights(ctx)
+    ctx.model.Minimize(
+        ctx.weekend_monday_night_penalty * ctx.weekend_monday_night_objective
+    )
+
+    solver = cp_model.CpSolver()
+    assert solver.Solve(ctx.model) == cp_model.OPTIMAL
+    assert solver.Value(ctx.planning[("Weekend", monday, "Nuit")]) == 0
+    assert solver.Value(ctx.planning[("Monday", monday, "Nuit")]) == 1
+
+
+def test_weekend_monday_night_sequence_remains_feasible_when_required():
+    ctx = _weekend_monday_night_context(["Required"])
+    for day in ctx.week_schedule:
+        ctx.model.Add(ctx.planning[("Required", day, "Nuit")] == 1)
+
+    penalize_weekend_monday_nights(ctx)
+    ctx.model.Minimize(
+        ctx.weekend_monday_night_penalty * ctx.weekend_monday_night_objective
+    )
+
+    solver = cp_model.CpSolver()
+    assert solver.Solve(ctx.model) == cp_model.OPTIMAL
+    assert solver.Value(ctx.weekend_monday_night_objective) == 1
+
+
+def test_generate_planning_accepts_required_weekend_monday_night_sequence():
+    agent = {
+        "name": "Only Night Agent",
+        "preferences": {"preferred": ["Nuit"], "avoid": []},
+        "restriction": [],
+        "unavailable": [],
+        "training": [],
+        "exclusion": [],
+        "vacations": [],
+    }
+    days = ["Sam. 10-01", "Dim. 11-01", "Lun. 12-01"]
+    runtime_config = {
+        "vacations": ["Nuit"],
+        "vacation_durations": {"Nuit": 12, "Conge": 7},
+        "vacation_metadata": {
+            "Nuit": {"is_night": True, "requires_next_day_rest": True}
+        },
+        "staffing_requirements": {"Nuit": 1},
+        "holidays": [],
+        "solver": {
+            "max_time_seconds": 30,
+            "relative_gap_limit": 0.1,
+            "num_search_workers": 0,
+            "global_max_gap": 240,
+            "period_max_gap": 240,
+            "max_weekly_hours": 36,
+            "optimize_period_balance": False,
+            "period_balance_weight": 2,
+            "min_free_weekends_per_horizon": 0,
+            "weekend_monday_night_penalty": 500,
+        },
+    }
+
+    result = generate_planning(
+        agents=[agent],
+        vacations=["Nuit"],
+        week_schedule=days,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={},
+        planning_start_date="2026-01-10",
+        runtime_config=runtime_config,
+    )
+
+    assert "info" not in result
+    assert result[agent["name"]] == [(day, "Nuit") for day in days]
+
+
+def test_generate_planning_uses_default_penalty_to_avoid_sequence():
+    weekend_agent = {
+        "name": "Weekend",
+        "preferences": {"preferred": ["Nuit"], "avoid": []},
+        "restriction": [],
+        "unavailable": [],
+        "training": [],
+        "exclusion": [],
+        "vacations": [],
+    }
+    alternative_agent = {
+        "name": "Alternative",
+        "preferences": {"preferred": [], "avoid": []},
+        "restriction": [],
+        "unavailable": [],
+        "training": [],
+        "exclusion": [],
+        "vacations": [],
+    }
+    days = ["Sam. 10-01", "Dim. 11-01", "Lun. 12-01"]
+    runtime_config = {
+        "vacations": ["Nuit"],
+        "vacation_durations": {"Nuit": 12, "Conge": 7},
+        "vacation_metadata": {
+            "Nuit": {"is_night": True, "requires_next_day_rest": True}
+        },
+        "staffing_requirements": {"Nuit": 1},
+        "holidays": [],
+        "solver": {
+            "max_time_seconds": 30,
+            "relative_gap_limit": 0.1,
+            "num_search_workers": 0,
+            "global_max_gap": 360,
+            "period_max_gap": 360,
+            "max_weekly_hours": 36,
+            "optimize_period_balance": False,
+            "period_balance_weight": 2,
+            "min_free_weekends_per_horizon": 0,
+        },
+    }
+
+    result = generate_planning(
+        agents=[weekend_agent, alternative_agent],
+        vacations=["Nuit"],
+        week_schedule=days,
+        dayOff={},
+        previous_week_schedule=[],
+        initial_shifts={"Weekend": [(days[0], "Nuit"), (days[1], "Nuit")]},
+        planning_start_date="2026-01-10",
+        runtime_config=runtime_config,
+    )
+
+    assert "info" not in result
+    assert (days[2], "Nuit") not in result["Weekend"]
+    assert (days[2], "Nuit") in result["Alternative"]
+
+
+def test_weekend_monday_night_sequence_is_counted_once_with_night_segments():
+    assignments = ["Nuit debut", "Nuit fin"]
+    ctx = _weekend_monday_night_context(["Segmented"], assignments)
+    forced = zip(ctx.week_schedule, ["Nuit debut", "Nuit fin", "Nuit debut"])
+    for day, assignment in forced:
+        ctx.model.Add(ctx.planning[("Segmented", day, assignment)] == 1)
+
+    penalize_weekend_monday_nights(ctx)
+
+    solver = cp_model.CpSolver()
+    assert solver.Solve(ctx.model) == cp_model.OPTIMAL
+    assert solver.Value(ctx.weekend_monday_night_objective) == 1
 
 
 def _solve_forced_paid_hours_balance(agents, apply_global=True, apply_period=True):

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -775,6 +775,12 @@ def test_relaxed_constraints_do_not_include_agent_minimum_assignment():
     assert "require_at_least_one_shift_per_agent" not in constraints
 
 
+def test_relaxed_constraints_do_not_include_soft_weekend_monday_nights():
+    constraints = [diagnostic["constraint"] for diagnostic in RELAXED_CONSTRAINT_DIAGNOSTICS]
+
+    assert "block_monday_night_after_weekend_nights" not in constraints
+
+
 def test_probe_relaxed_hard_constraints_uses_generic_rest_wording():
     config = deepcopy(load_default_config())
 

--- a/backend/tests/test_solver_modularization.py
+++ b/backend/tests/test_solver_modularization.py
@@ -124,6 +124,15 @@ def test_registry_contains_constraint_groups():
     assert len(registry.mixed) > 0
 
 
+def test_weekend_monday_nights_are_registered_as_soft_only():
+    registry = _build_registry()
+    hard_names = {constraint.__name__ for constraint in registry.hard}
+    soft_names = {constraint.__name__ for constraint in registry.soft}
+
+    assert "block_monday_night_after_weekend_nights" not in hard_names
+    assert "penalize_weekend_monday_nights" in soft_names
+
+
 def test_night_shift_blocks_next_day_jour_or_cdp():
     """
     Tests that night shifts block the next day from being assigned to

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -213,6 +213,9 @@ Supported keys:
   - Maximum paid-hour balance gap between agents inside each period, in tenths of hours.
 - `optimize_period_balance` (boolean, default `false`)
 - `period_balance_weight` (integer, default `2`)
+- `weekend_monday_night_penalty` (integer, default `500`)
+  - Objective penalty applied once per agent for each consecutive Saturday, Sunday, and Monday all worked on night assignments.
+  - Higher values make this sequence less desirable without making it infeasible; set to `0` to disable the preference.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Objective

Convert the Saturday/Sunday/Monday consecutive night restriction from a hard constraint into a configurable soft preference, allowing required coverage and locked manual schedules to remain feasible.

## Breaking Change Notice

No API breaking change.

The solver may now accept a Saturday/Sunday/Monday night sequence when required. By default, it still avoids this sequence through a configurable objective penalty.

## Scope

- Remove `block_monday_night_after_weekend_nights` from the hard constraint registry.
- Add a soft constraint that detects each consecutive Saturday, Sunday, and Monday night sequence per agent.
- Support full and segmented night assignments through existing vacation metadata.
- Add configurable `solver.weekend_monday_night_penalty`, with a default value of `500`.
- Allow a value of `0` to disable the preference.
- Add the sequence penalty to the solver objective.
- Remove the former hard constraint from infeasibility diagnostics.
- Update the configuration schema, example configuration, and reference documentation.
- Keep all other night, rest, balancing, and coverage rules unchanged.
- Add targeted solver, registry, schema, and diagnostic regression tests.

## Validation

- `backend/.venv/Scripts/python.exe -m pytest -q`

## Results

- Full backend test suite passes: `152/152`.
- The solver avoids the sequence when a reasonable alternative exists.
- The sequence remains feasible when required for coverage or locked manual assignments.
- Night segments are detected without applying duplicate penalties.
- The former rule is no longer reported as a hard infeasibility cause.

## Risks and Mitigations

- Risk: a penalty that is too low may allow the sequence more often than expected.
- Mitigation: `solver.weekend_monday_night_penalty` is configurable and defaults to `500`.

- Risk: a high penalty may influence other soft optimization choices.
- Mitigation: coverage and rest requirements remain hard constraints, while manual assignment preservation keeps its higher priority.